### PR TITLE
chore: release v26.8.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
+
+## [26.8.19] - 2026-08-19
+
+### Added
+
+- **task-v2**: render tool-generated media inline in chat
+
+### Fixed
+
+- **agent**: let skill-enabled profiles download media instead of refusing
+- **task-v2**: stop rendering AskUserQuestion answers twice
+- **agent**: unblock codex network access and unwrap JSON envelopes
+- **ag-ui**: create the run row before journaling its first event
+- **task-v2**: resolve the session folder when task.work_dir is empty
+- skill-based downloads and inline media rendering in chat- #1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neumar",
-  "version": "26.8.9",
+  "version": "26.8.19",
   "private": true,
   "license": "Apache-2.0",
   "repository": {

--- a/src-api/package.json
+++ b/src-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neumar-api",
-  "version": "26.8.9",
+  "version": "26.8.19",
   "type": "module",
   "scripts": {
     "predev": "pnpm --filter @neumar/video-ir build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neumar"
-version = "26.8.9"
+version = "26.8.19"
 description = "A desktop AI agent application that works tirelessly like a bull and horse to execute tasks through natural language."
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Neumar",
-  "version": "26.8.9",
+  "version": "26.8.19",
   "identifier": "ai.neumar",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- Bump version to 26.8.19 across package.json, src-api/package.json, tauri.conf.json, Cargo.toml
- Add CHANGELOG.md entry for v26.8.19

## Test plan
- N/A (version bump only)