### PR TITLE
fix(task-v2): isolate task state and recover runs

### DIFF
--- a/src-api/src/app/api/ag-ui.ts
+++ b/src-api/src/app/api/ag-ui.ts
@@ -1329,6 +1329,7 @@ agui.get('/history/:taskId', async (c) => {
   const taskId = parsed.data;
   const dbMessages = getMessagesByTaskId(taskId);
   const aguiMessages = dbMessagesToFullAGUI(dbMessages);
+  const taskStatus = getTask(taskId)?.status;
   const activeBusKey = activeRunBusKeys.get(taskId);
   const activeRunContext =
     activeBusKey && taskEventBus.isTaskActive(activeBusKey)
@@ -1339,6 +1340,7 @@ agui.get('/history/:taskId', async (c) => {
     messages: aguiMessages,
     files,
     isRunning: activeBusKey ? taskEventBus.isTaskActive(activeBusKey) : false,
+    taskStatus,
   });
 });
 

--- a/src-api/src/extensions/agent/claude/index.ts
+++ b/src-api/src/extensions/agent/claude/index.ts
@@ -233,6 +233,7 @@ import { safeAsyncGenerator } from '@/shared/utils/stream-cleanup';
 import { ContainerManager, executePTC } from './ptc';
 import { adaptMcpTools } from './ptc-adapter';
 import type { ToolHandler } from './ptc-types';
+import { hasClaudeSdkStalled } from './stall-policy';
 
 /**
  * Whether built-in MCP servers should be registered for this profile.
@@ -700,9 +701,6 @@ const PLANNING_HEARTBEAT_MS = 3_000;
 
 /** Log a warning if no SDK message received for this long during planning */
 const PLANNING_STALL_WARN_MS = 30_000;
-
-/** Abort planning if no SDK message received for this long (subprocess likely hung) */
-const PLANNING_STALL_ABORT_MS = 120_000;
 
 /**
  * Merges an async iterable with periodic heartbeats using Promise.race.
@@ -3808,7 +3806,7 @@ User's request (answer this AFTER reading the images):
 
           if (typeof raw === 'object' && raw !== null && '_heartbeat' in raw) {
             const stallMs = Date.now() - lastSdkMessageTime;
-            if (stallMs >= PLANNING_STALL_ABORT_MS) {
+            if (hasClaudeSdkStalled(stallMs)) {
               queryStalled = true;
               logger.error(
                 `[Claude ${session.id}] Direct run stalled ${Math.round(stallMs / 1000)}s — aborting (${sdkMessageCount} SDK msgs)`,
@@ -4759,7 +4757,7 @@ When the user asks to schedule, remind, monitor, check periodically, or set up a
 
           if (typeof raw === 'object' && raw !== null && '_heartbeat' in raw) {
             const stallMs = Date.now() - lastPlanMsgTime;
-            if (stallMs >= PLANNING_STALL_ABORT_MS) {
+            if (hasClaudeSdkStalled(stallMs)) {
               logger.error(
                 `[Claude ${session.id}] Planning stalled ${Math.round(stallMs / 1000)}s — aborting (${planMsgCount} msgs, response=${fullResponse.length} chars)`,
               );

--- a/src-api/src/extensions/agent/claude/stall-policy.ts
+++ b/src-api/src/extensions/agent/claude/stall-policy.ts
@@ -1,0 +1,9 @@
+/**
+ * Maximum time to wait for a complete Claude SDK message before aborting.
+ * Partial messages are disabled, so large tool inputs can be silent for minutes.
+ */
+export const CLAUDE_SDK_STALL_ABORT_MS = 10 * 60 * 1_000;
+
+export function hasClaudeSdkStalled(stallMs: number): boolean {
+  return stallMs >= CLAUDE_SDK_STALL_ABORT_MS;
+}

--- a/src-api/src/shared/services/ag-ui/persistence.ts
+++ b/src-api/src/shared/services/ag-ui/persistence.ts
@@ -29,6 +29,7 @@ import {
   updateAgentRunAttempt,
   updateAgentRunDelivery,
   updateTask,
+  updateTaskHeartbeat,
 } from '@/shared/db/operations';
 import {
   createTraceArtifactReference,
@@ -303,6 +304,10 @@ export class AGUIEventPersister {
     try {
       switch (event.type) {
         case EventType.RUN_STARTED: {
+          if (this.mode === 'task') {
+            updateTask(this.taskId, { status: 'running' });
+            updateTaskHeartbeat(this.taskId);
+          }
           this.ensureRootRunRow();
           this.rootTraceEventId = this.runId ?? crypto.randomUUID();
           recordTraceEvent({

--- a/src-api/test/unit/extensions/agent/claude/stall-policy.test.ts
+++ b/src-api/test/unit/extensions/agent/claude/stall-policy.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasClaudeSdkStalled } from '@/extensions/agent/claude/stall-policy';
+
+describe('Claude SDK stall policy', () => {
+  it('allows long complete-message generation but eventually aborts a hung SDK', () => {
+    expect(hasClaudeSdkStalled(120_000)).toBe(false);
+    expect(hasClaudeSdkStalled(599_999)).toBe(false);
+    expect(hasClaudeSdkStalled(600_000)).toBe(true);
+  });
+});

--- a/src-api/test/unit/services/ag-ui/persistence.test.ts
+++ b/src-api/test/unit/services/ag-ui/persistence.test.ts
@@ -17,6 +17,7 @@ import {
   getAgentRunsByTaskId,
   getFilesByTaskId,
   getTask,
+  updateTask,
 } from '@/shared/db/operations';
 import { buildExecutionDiagnostics } from '@/shared/observability/execution-diagnostics';
 import { listTraceEvents } from '@/shared/observability/trace';
@@ -98,6 +99,21 @@ describe('AGUIEventPersister persistence', () => {
     expect(getFilesByTaskId(taskId).map((file) => file.path)).toEqual([
       outputPath,
     ]);
+  });
+
+  it('resets an errored task to running when a new run starts', () => {
+    const { sessionCwd, taskId, workspaceRoot } = createTaskFixture();
+    updateTask(taskId, { status: 'error' });
+    const persister = new AGUIEventPersister(
+      taskId,
+      'run-retry',
+      workspaceRoot,
+      sessionCwd,
+    );
+
+    persister.handleEvent({ type: EventType.RUN_STARTED } as never);
+
+    expect(getTask(taskId)?.status).toBe('running');
   });
 
   it('keeps explicitly saved files even when they are outside output directories', () => {

--- a/src/__tests__/InitialMessageSender.test.tsx
+++ b/src/__tests__/InitialMessageSender.test.tsx
@@ -21,6 +21,7 @@ import type { Message, Session, Task } from '@/shared/db';
 const agentMocks = vi.hoisted(() => ({
   addMessage: vi.fn(),
   runAgent: vi.fn().mockResolvedValue(undefined),
+  setMessages: vi.fn(),
 }));
 
 vi.mock('@copilotkit/react-core/v2', () => ({
@@ -28,6 +29,7 @@ vi.mock('@copilotkit/react-core/v2', () => ({
     agent: {
       addMessage: agentMocks.addMessage,
       runAgent: agentMocks.runAgent,
+      setMessages: agentMocks.setMessages,
     },
   }),
   useCopilotKit: () => ({
@@ -76,6 +78,10 @@ describe('InitialMessageSender', () => {
         type: 'user',
         content: 'Draft a launch plan',
       }),
+    );
+    expect(agentMocks.setMessages).toHaveBeenCalledWith([]);
+    expect(agentMocks.setMessages.mock.invocationCallOrder[0]).toBeLessThan(
+      agentMocks.addMessage.mock.invocationCallOrder[0],
     );
     expect(screen.getByTestId('location-state')).toHaveTextContent('null');
   });

--- a/src/__tests__/agui-provider.hydration.test.tsx
+++ b/src/__tests__/agui-provider.hydration.test.tsx
@@ -1,0 +1,111 @@
+import type { ReactNode } from 'react';
+
+import { act, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgUiProvider } from '@/shared/providers/agui-provider';
+import { useThreadStore } from '@/shared/stores/thread-store';
+
+const agentMocks = vi.hoisted(() => {
+  const agent = {
+    isRunning: false,
+    messages: [] as Array<{ id: string; role: string; content: string }>,
+    setMessages: vi.fn(),
+    subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
+  };
+  agent.setMessages.mockImplementation((messages) => {
+    agent.messages = messages;
+  });
+  return { agent };
+});
+
+vi.mock('@copilotkit/react-core/v2', () => ({
+  CopilotKit: ({ children }: { children: ReactNode }) => children,
+  useAgent: () => ({ agent: agentMocks.agent }),
+}));
+
+vi.mock('@/config', () => ({
+  API_BASE_URL: 'http://localhost:5126',
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function historyResponse(
+  messages: Array<{ id: string; role: 'assistant'; content: string }>,
+) {
+  return {
+    files: [],
+    isRunning: false,
+    messages,
+  };
+}
+
+describe('AgUiProvider history hydration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agentMocks.agent.messages = [];
+    useThreadStore.setState({ threads: {} });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('ignores an older history response that finishes after a task switch', async () => {
+    const oldJson = deferred<ReturnType<typeof historyResponse>>();
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/ag-ui/history/old-task')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => oldJson.promise,
+        } as Response);
+      }
+      if (url.endsWith('/ag-ui/history/new-task')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve(
+              historyResponse([
+                { id: 'new-answer', role: 'assistant', content: 'New task' },
+              ]),
+            ),
+        } as Response);
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const view = render(<AgUiProvider threadId="old-task">old</AgUiProvider>);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    view.rerender(<AgUiProvider threadId="new-task">new</AgUiProvider>);
+    await waitFor(() => {
+      expect(useThreadStore.getState().threads['new-task']?.messages).toEqual([
+        { id: 'new-answer', role: 'assistant', content: 'New task' },
+      ]);
+    });
+
+    await act(async () => {
+      oldJson.resolve(
+        historyResponse([
+          { id: 'old-answer', role: 'assistant', content: 'Old task' },
+        ]),
+      );
+      await oldJson.promise;
+    });
+
+    expect(agentMocks.agent.messages).toEqual([
+      { id: 'new-answer', role: 'assistant', content: 'New task' },
+    ]);
+    expect(useThreadStore.getState().threads['old-task']?.messages).not.toEqual(
+      [{ id: 'old-answer', role: 'assistant', content: 'Old task' }],
+    );
+  });
+});

--- a/src/__tests__/components/task/outputArtifactItems.test.ts
+++ b/src/__tests__/components/task/outputArtifactItems.test.ts
@@ -22,6 +22,15 @@ describe('appendOutputArtifactsItem', () => {
     const items: GroupedItem[] = [
       {
         type: 'message',
+        key: 'draft',
+        msg: {
+          id: 'draft',
+          role: 'assistant',
+          content: `Draft render: [agent-system-illustration.mp4](${ORIGINAL_PATH})`,
+        },
+      },
+      {
+        type: 'message',
         key: 'answer',
         msg: {
           id: 'answer',
@@ -34,6 +43,31 @@ describe('appendOutputArtifactsItem', () => {
     const result = appendOutputArtifactsItem(items, [
       video('original', ORIGINAL_PATH),
       video('final', FINAL_PATH),
+    ]);
+
+    expect(result.at(-1)).toMatchObject({
+      type: 'output-artifacts',
+      artifacts: [{ id: 'final' }],
+    });
+  });
+
+  it('does not match an output whose name is only a substring of the final deliverable', () => {
+    const items: GroupedItem[] = [
+      {
+        type: 'message',
+        key: 'answer',
+        msg: {
+          id: 'answer',
+          role: 'assistant',
+          content:
+            'Final deliverable: [final-report.mp4](/tmp/output/final-report.mp4)',
+        },
+      },
+    ];
+
+    const result = appendOutputArtifactsItem(items, [
+      video('partial', '/tmp/output/report.mp4'),
+      video('final', '/tmp/output/final-report.mp4'),
     ]);
 
     expect(result.at(-1)).toMatchObject({

--- a/src/__tests__/components/task/outputArtifactItems.test.ts
+++ b/src/__tests__/components/task/outputArtifactItems.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Artifact } from '@/components/artifacts/types';
+import type { GroupedItem } from '@/components/task/groupMessages';
+import { appendOutputArtifactsItem } from '@/components/task/outputArtifactItems';
+
+const ORIGINAL_PATH = '/tmp/output/agent-system-illustration.mp4';
+const FINAL_PATH = '/tmp/output/agent-system-illustration_2.mp4';
+
+function video(id: string, path: string): Artifact {
+  return {
+    id,
+    name: path.split('/').at(-1) ?? path,
+    path,
+    type: 'video',
+    isOutput: true,
+  };
+}
+
+describe('appendOutputArtifactsItem', () => {
+  it('previews only deliverables linked by the final assistant answer', () => {
+    const items: GroupedItem[] = [
+      {
+        type: 'message',
+        key: 'answer',
+        msg: {
+          id: 'answer',
+          role: 'assistant',
+          content: `Final deliverable: [agent-system-illustration_2.mp4](${FINAL_PATH})`,
+        },
+      },
+    ];
+
+    const result = appendOutputArtifactsItem(items, [
+      video('original', ORIGINAL_PATH),
+      video('final', FINAL_PATH),
+    ]);
+
+    expect(result.at(-1)).toMatchObject({
+      type: 'output-artifacts',
+      artifacts: [{ id: 'final' }],
+    });
+  });
+
+  it('keeps all previewable outputs when the final answer names none', () => {
+    const items: GroupedItem[] = [];
+    const result = appendOutputArtifactsItem(items, [
+      video('part-1', '/tmp/output/part-1.mp4'),
+      video('part-2', '/tmp/output/part-2.mp4'),
+    ]);
+
+    expect(result.at(-1)).toMatchObject({
+      type: 'output-artifacts',
+      artifacts: [{ id: 'part-1' }, { id: 'part-2' }],
+    });
+  });
+});

--- a/src/__tests__/components/task/outputArtifactMedia.test.ts
+++ b/src/__tests__/components/task/outputArtifactMedia.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Artifact } from '@/components/artifacts/types';
-import { filterOutputArtifactMedia } from '@/components/task/outputArtifactMedia';
+import {
+  filterOutputArtifactMedia,
+  getPreviewableOutputArtifacts,
+} from '@/components/task/outputArtifactMedia';
 
 function imageArtifact(overrides: Partial<Artifact>): Artifact {
   return {
@@ -75,5 +78,32 @@ describe('filterOutputArtifactMedia', () => {
     );
 
     expect(filtered.pdfs).toEqual([{ path: documentPath }]);
+  });
+});
+
+describe('getPreviewableOutputArtifacts', () => {
+  it('keeps final media but omits render-frame sequences from chat', () => {
+    const artifacts = [
+      imageArtifact({
+        id: 'frame-1',
+        name: 'frame_0001.png',
+        path: '/tmp/session/output/agent_system_frames_2/frame_0001.png',
+      }),
+      imageArtifact({
+        id: 'frame-pattern',
+        name: 'frame_%04d.png',
+        path: '/tmp/session/output/agent_system_frames_2/frame_%04d.png',
+      }),
+      imageArtifact({
+        id: 'video-1',
+        name: 'agent-system-illustration.mp4',
+        path: '/tmp/session/output/agent-system-illustration.mp4',
+        type: 'video',
+      }),
+    ];
+
+    expect(getPreviewableOutputArtifacts(artifacts).map((a) => a.name)).toEqual(
+      ['agent-system-illustration.mp4'],
+    );
   });
 });

--- a/src/__tests__/task-files.ownership.test.ts
+++ b/src/__tests__/task-files.ownership.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { isTaskOwnedFilePath } from '@/shared/lib/task-files';
+
+describe('isTaskOwnedFilePath', () => {
+  it('rejects files stored under a different task session', () => {
+    expect(
+      isTaskOwnedFilePath(
+        '/Users/me/.neumar/sessions/session-task-old/output/old.mp4',
+        'task-current',
+      ),
+    ).toBe(false);
+  });
+
+  it('keeps current-session and non-session paths', () => {
+    expect(
+      isTaskOwnedFilePath(
+        '/Users/me/.neumar/sessions/session-task-current/output/final.mp4',
+        'task-current',
+      ),
+    ).toBe(true);
+    expect(
+      isTaskOwnedFilePath('https://example.com/reference', 'task-current'),
+    ).toBe(true);
+  });
+});

--- a/src/__tests__/useRunError.interrupted.test.tsx
+++ b/src/__tests__/useRunError.interrupted.test.tsx
@@ -1,0 +1,49 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useRunError } from '@/shared/hooks/useRunError';
+
+describe('useRunError interrupted-run recovery', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('stops a stale local run when the backend marked it as failed', async () => {
+    vi.useFakeTimers();
+    const abortRun = vi.fn();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          isRunning: false,
+          taskStatus: 'error',
+          messages: [
+            { role: 'user', content: 'make a video' },
+            { role: 'assistant', content: 'I created partial output' },
+          ],
+        }),
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useRunError(
+        'task-1',
+        {
+          messages: [{ role: 'user', content: 'make a video' }],
+          isRunning: true,
+          abortRun,
+        },
+        'Agent run failed',
+      ),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(result.current.runError).toBe('Agent run failed');
+    expect(abortRun).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/task/InitialMessageSender.tsx
+++ b/src/components/task/InitialMessageSender.tsx
@@ -288,6 +288,9 @@ export function InitialMessageSender({
 
       // Use agentRef to avoid stale closure after async await
       const a = agentRef.current;
+      // CopilotKit keeps one agent instance across keyed task providers. A new
+      // task must not inherit the previous task's transcript.
+      a.setMessages([]);
       a.addMessage({ id: msgId, role: 'user', content: prompt });
       const additionalDirs = locState?.additionalWorkDirs;
       const assigneeProfileId = locState?.assigneeProfileId;

--- a/src/components/task/TaskV2Thread.tsx
+++ b/src/components/task/TaskV2Thread.tsx
@@ -42,7 +42,10 @@ import { useV2FileExtraction } from '@/shared/hooks/useV2FileExtraction';
 import { toAgentSeedMessages } from '@/shared/lib/message-tree';
 import { useLanguage } from '@/shared/providers/language-provider';
 import { useBranchStore } from '@/shared/stores/branch-store';
-import { useThreadStore } from '@/shared/stores/thread-store';
+import {
+  useThreadHydration,
+  useThreadStore,
+} from '@/shared/stores/thread-store';
 import { randomUUID } from '@/shared/utils/uuid';
 
 const EMPTY_MESSAGES: unknown[] = []; // Stable selector fallback.
@@ -141,14 +144,17 @@ export function TaskV2Thread({
   const cachedMessages = useThreadStore(
     (s) => s.threads[taskId ?? '']?.messages ?? EMPTY_MESSAGES,
   ) as AGUIMessage[];
+  const hydrationState = useThreadHydration(taskId);
   const messages = useMemo(
     () =>
-      agentMessages.length > 0
-        ? agentMessages
-        : cachedMessages.length > 0
-          ? cachedMessages
-          : ((historyMessages ?? []) as AGUIMessage[]),
-    [agentMessages, cachedMessages, historyMessages],
+      hydrationState === 'pending'
+        ? []
+        : agentMessages.length > 0
+          ? agentMessages
+          : cachedMessages.length > 0
+            ? cachedMessages
+            : ((historyMessages ?? []) as AGUIMessage[]),
+    [agentMessages, cachedMessages, historyMessages, hydrationState],
   );
 
   // Bridge ChatInput's onSubmit to CopilotKit headless agent.

--- a/src/components/task/outputArtifactItems.ts
+++ b/src/components/task/outputArtifactItems.ts
@@ -7,7 +7,11 @@ export function appendOutputArtifactsItem(
   items: GroupedItem[],
   artifacts: Artifact[] | undefined,
 ): GroupedItem[] {
-  const outputArtifacts = getPreviewableOutputArtifacts(artifacts ?? []);
+  const previewableArtifacts = getPreviewableOutputArtifacts(artifacts ?? []);
+  const outputArtifacts = selectReferencedDeliverables(
+    items,
+    previewableArtifacts,
+  );
   if (outputArtifacts.length === 0) return items;
   return [
     ...items,
@@ -17,4 +21,23 @@ export function appendOutputArtifactsItem(
       artifacts: outputArtifacts,
     },
   ];
+}
+
+function selectReferencedDeliverables(
+  items: GroupedItem[],
+  artifacts: Artifact[],
+): Artifact[] {
+  const finalAnswer = items
+    .filter((item) => item.type === 'message' && item.msg.role === 'assistant')
+    .map((item) => (item.type === 'message' ? item.msg.content : ''))
+    .join('\n');
+
+  if (!finalAnswer) return artifacts;
+
+  const referenced = artifacts.filter(
+    (artifact) =>
+      (artifact.path && finalAnswer.includes(artifact.path)) ||
+      finalAnswer.includes(artifact.name),
+  );
+  return referenced.length > 0 ? referenced : artifacts;
 }

--- a/src/components/task/outputArtifactItems.ts
+++ b/src/components/task/outputArtifactItems.ts
@@ -1,7 +1,10 @@
 import type { Artifact } from '@/components/artifacts/types';
 
-import type { GroupedItem } from './GroupedMessageList';
+import type { GroupedItem } from './groupMessages';
 import { getPreviewableOutputArtifacts } from './outputArtifactMedia';
+
+const REFERENCE_PREFIX = String.raw`(^|[\s([{"'\x60])`;
+const REFERENCE_SUFFIX = String.raw`(?=$|[\s)\]},"'\x60.:;!?])`;
 
 export function appendOutputArtifactsItem(
   items: GroupedItem[],
@@ -27,17 +30,31 @@ function selectReferencedDeliverables(
   items: GroupedItem[],
   artifacts: Artifact[],
 ): Artifact[] {
-  const finalAnswer = items
-    .filter((item) => item.type === 'message' && item.msg.role === 'assistant')
-    .map((item) => (item.type === 'message' ? item.msg.content : ''))
-    .join('\n');
+  const finalAnswer = getFinalAssistantAnswer(items);
 
   if (!finalAnswer) return artifacts;
 
   const referenced = artifacts.filter(
     (artifact) =>
-      (artifact.path && finalAnswer.includes(artifact.path)) ||
-      finalAnswer.includes(artifact.name),
+      (artifact.path && hasExactReference(finalAnswer, artifact.path)) ||
+      hasExactReference(finalAnswer, artifact.name),
   );
   return referenced.length > 0 ? referenced : artifacts;
+}
+
+function getFinalAssistantAnswer(items: GroupedItem[]): string | undefined {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index];
+    if (item.type === 'message' && item.msg.role === 'assistant') {
+      return item.msg.content;
+    }
+  }
+  return undefined;
+}
+
+function hasExactReference(content: string, reference: string): boolean {
+  const escaped = reference.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`${REFERENCE_PREFIX}${escaped}${REFERENCE_SUFFIX}`).test(
+    content,
+  );
 }

--- a/src/components/task/outputArtifactMedia.ts
+++ b/src/components/task/outputArtifactMedia.ts
@@ -2,6 +2,7 @@ import type { Artifact } from '@/components/artifacts/types';
 import type { MediaAsset } from '@/shared/lib/provenance';
 
 const INLINE_OUTPUT_TYPES = new Set(['image', 'video', 'audio']);
+const RENDER_FRAME_NAME_RE = /^frame_(?:%0?\d*d|\d+)\.(?:png|jpe?g|webp)$/i;
 
 export interface OutputPreviewGroup {
   key: string;
@@ -22,6 +23,9 @@ export function getPreviewableOutputArtifacts(artifacts: Artifact[] = []) {
   for (const artifact of artifacts) {
     if (!artifact.isOutput || !artifact.path) continue;
     if (!INLINE_OUTPUT_TYPES.has(artifact.type)) continue;
+    if (artifact.type === 'image' && RENDER_FRAME_NAME_RE.test(artifact.name)) {
+      continue;
+    }
     const key = artifact.path;
     if (seen.has(key)) continue;
     seen.add(key);

--- a/src/shared/hooks/useRunError.ts
+++ b/src/shared/hooks/useRunError.ts
@@ -62,6 +62,7 @@ export function useRunError(
         if (!res.ok) return;
         const data = (await res.json()) as {
           isRunning?: boolean;
+          taskStatus?: 'running' | 'completed' | 'error' | 'stopped';
           messages?: Array<{
             role: string;
             content?: string;
@@ -84,13 +85,13 @@ export function useRunError(
               !m.isError,
           );
 
-          if (errorMsg) {
+          if (errorMsg || data.taskStatus === 'error') {
             try {
               agentRef.current.abortRun();
             } catch {
               /* */
             }
-            setRunError(errorMsg.content!);
+            setRunError(errorMsg?.content || agentRunFailedLabel);
           } else if (!hasRealContent) {
             try {
               agentRef.current.abortRun();

--- a/src/shared/hooks/useV2Artifacts.ts
+++ b/src/shared/hooks/useV2Artifacts.ts
@@ -11,6 +11,7 @@ import type { LibraryFile } from '@/shared/db/types';
 import {
   inferTaskFileRunId,
   isPromotedInputPath,
+  isTaskOwnedFilePath,
   libraryFileToTaskFile,
 } from '@/shared/lib/task-files';
 import { useTaskFiles, useThreadStore } from '@/shared/stores/thread-store';
@@ -120,8 +121,11 @@ export function useV2Artifacts(taskId: string): Artifact[] {
   const hasFileIndex = useThreadStore((s) => s.threads[taskId] !== undefined);
 
   const cachedArtifacts = useMemo(
-    () => cachedFiles.map(taskFileToArtifact),
-    [cachedFiles],
+    () =>
+      cachedFiles
+        .filter((file) => isTaskOwnedFilePath(file.path, taskId))
+        .map(taskFileToArtifact),
+    [cachedFiles, taskId],
   );
 
   useEffect(() => {
@@ -132,8 +136,11 @@ export function useV2Artifacts(taskId: string): Artifact[] {
       try {
         const files = await getFilesByTaskId(taskId);
         if (!cancelled) {
-          setFiles(taskId, files.map(libraryFileToTaskFile));
-          setArtifacts(files.map(libraryFileToArtifact));
+          const ownedFiles = files.filter((file) =>
+            isTaskOwnedFilePath(file.path, taskId),
+          );
+          setFiles(taskId, ownedFiles.map(libraryFileToTaskFile));
+          setArtifacts(ownedFiles.map(libraryFileToArtifact));
         }
       } catch {
         // non-critical — artifacts panel is optional

--- a/src/shared/lib/task-files.ts
+++ b/src/shared/lib/task-files.ts
@@ -1,6 +1,8 @@
 import type { LibraryFile } from '@/shared/db/types';
 import type { TaskFile } from '@/shared/stores/thread-store';
 
+const SESSION_TASK_PATH_RE = /[\\/]sessions[\\/]session-([^\\/]+)(?:[\\/]|$)/i;
+
 export function libraryFileToTaskFile(file: LibraryFile): TaskFile {
   const role = isPromotedInputPath(file.path) ? 'input' : undefined;
   return {
@@ -25,6 +27,15 @@ export function inferTaskFileRunId(
 
 export function isPromotedInputPath(path: string | undefined): boolean {
   return /[\\/]output[\\/][^\\/]+[\\/]inputs[\\/]/i.test(path ?? '');
+}
+
+/** Rejects persisted file rows whose session path belongs to another task. */
+export function isTaskOwnedFilePath(
+  path: string | undefined,
+  taskId: string,
+): boolean {
+  const pathTaskId = path?.match(SESSION_TASK_PATH_RE)?.[1];
+  return pathTaskId === undefined || pathTaskId === taskId;
 }
 
 export function libraryFileTypeToTaskFileKind(

--- a/src/shared/providers/agui-provider.tsx
+++ b/src/shared/providers/agui-provider.tsx
@@ -164,8 +164,9 @@ function AgUiProviderInner({
   // On mount and thread switch: fetch full history from backend and populate Zustand cache.
   // Brand-new tasks still get an empty hydrated cache entry so re-entry is deterministic.
   useEffect(() => {
+    agent.setMessages([]);
+
     if (isNewTask) {
-      agent.setMessages([]);
       hydrateFromDB(threadId, [], false, { files: [] });
       return;
     }
@@ -179,22 +180,30 @@ function AgUiProviderInner({
           signal: ctrl.signal,
         });
         if (!res.ok) {
-          setHydrationState(threadId, 'error');
+          if (!ctrl.signal.aborted) {
+            setHydrationState(threadId, 'error');
+          }
           return;
         }
         const history = parseHistoryResponse(await res.json());
         if (!history) {
-          setHydrationState(threadId, 'error');
+          if (!ctrl.signal.aborted) {
+            setHydrationState(threadId, 'error');
+          }
           return;
         }
+        const files =
+          history.files ?? (await fetchTaskFiles(threadId, ctrl.signal));
+        if (ctrl.signal.aborted) return;
+
         agent.setMessages(
           history.messages as Parameters<typeof agent.setMessages>[0],
         );
         hydrateFromDB(threadId, history.messages, history.isRunning, {
-          files: history.files ?? (await fetchTaskFiles(threadId, ctrl.signal)),
+          files,
         });
       } catch (error) {
-        if ((error as Error).name !== 'AbortError') {
+        if (!ctrl.signal.aborted && (error as Error).name !== 'AbortError') {
           setHydrationState(threadId, 'error');
         }
       }

--- a/src/shared/providers/agui-provider.tsx
+++ b/src/shared/providers/agui-provider.tsx
@@ -165,6 +165,7 @@ function AgUiProviderInner({
   // Brand-new tasks still get an empty hydrated cache entry so re-entry is deterministic.
   useEffect(() => {
     if (isNewTask) {
+      agent.setMessages([]);
       hydrateFromDB(threadId, [], false, { files: [] });
       return;
     }
@@ -186,6 +187,9 @@ function AgUiProviderInner({
           setHydrationState(threadId, 'error');
           return;
         }
+        agent.setMessages(
+          history.messages as Parameters<typeof agent.setMessages>[0],
+        );
         hydrateFromDB(threadId, history.messages, history.isRunning, {
           files: history.files ?? (await fetchTaskFiles(threadId, ctrl.signal)),
         });
@@ -197,7 +201,7 @@ function AgUiProviderInner({
     })();
 
     return () => ctrl.abort();
-  }, [threadId, isNewTask, hydrateFromDB, setHydrationState]);
+  }, [agent, threadId, isNewTask, hydrateFromDB, setHydrationState]);
 
   // Mirror active CopilotKit messages into Zustand on every mutation. The
   // active agent remains authoritative while mounted; the store becomes an


### PR DESCRIPTION
## Summary

Prevent task-v2 sessions from inheriting another task's transcript or output files, and make interrupted agent runs recover cleanly instead of leaving the UI stuck in a running state.

## Changes

- Reset and hydrate CopilotKit messages per task, gating message consumers until hydration completes.
- Reject persisted artifact paths owned by another task and omit render frames or superseded media from completed chat deliverables.
- Restore errored tasks to running when retries start and expose persisted task status to the client watchdog.
- Extend the Claude SDK complete-message stall window so large tool inputs are not aborted prematurely.
- Add focused regression coverage for run recovery, message isolation, artifact ownership, frame filtering, and final deliverable selection.

## Testing

- `pnpm validate`
- Frontend focused suite: 6 files, 19 tests passed
- API focused suite: 2 files, 10 tests passed
- Full frontend suite: 282 files, 1,204 tests passed
- Chrome validation: task switching keeps transcripts and videos isolated; only the explicitly linked final video renders in chat

The broader API suite was also attempted. It reported 18 environment-related failures from blocked DNS/localhost binding and file-watcher limits; the focused API tests for this change pass.

## Breaking Changes

None.

## Migration Required

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task history now reports the current task status.
  * Task threads and agent transcripts hydrate more reliably when switching or resuming tasks.
  * New task creation starts with a clean message history.

* **Bug Fixes**
  * Improved detection and recovery of failed or stalled runs.
  * Task-owned files are now protected from appearing in another task’s artifacts.
  * Output previews show only relevant deliverables and exclude render-frame images.
  * Restarted tasks correctly return to a running state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->