### PR TITLE
feat(library): make project grids responsive

### DIFF
--- a/src/__tests__/DesignsTab.test.tsx
+++ b/src/__tests__/DesignsTab.test.tsx
@@ -53,6 +53,9 @@ describe('DesignsTab cards', () => {
     );
 
     const preview = await screen.findByTitle('Project design_card_1 preview');
+    expect(
+      document.querySelector<HTMLElement>('[class*="auto-fill"]')?.className,
+    ).toContain('22rem');
     expect(preview).toHaveAttribute('sandbox', SANDBOX_ATTR);
     expect(preview.closest('.pointer-events-none')).toBeTruthy();
 

--- a/src/__tests__/DesignsTab.test.tsx
+++ b/src/__tests__/DesignsTab.test.tsx
@@ -39,7 +39,7 @@ describe('DesignsTab cards', () => {
     const onRename = vi.fn();
     const onDelete = vi.fn();
 
-    renderWithProviders(
+    const view = renderWithProviders(
       <DesignsTab
         projects={[
           projectFixture('design_card_1'),
@@ -54,8 +54,9 @@ describe('DesignsTab cards', () => {
 
     const preview = await screen.findByTitle('Project design_card_1 preview');
     expect(
-      document.querySelector<HTMLElement>('[class*="auto-fill"]')?.className,
-    ).toContain('22rem');
+      view.container.querySelector<HTMLElement>('[class*="auto-fill"]')
+        ?.className,
+    ).toContain('352px');
     expect(preview).toHaveAttribute('sandbox', SANDBOX_ATTR);
     expect(preview.closest('.pointer-events-none')).toBeTruthy();
 

--- a/src/__tests__/DesignsTab.virtualization.test.tsx
+++ b/src/__tests__/DesignsTab.virtualization.test.tsx
@@ -96,7 +96,7 @@ describe('DesignsTab virtualization interactions', () => {
     await user.click(screen.getAllByLabelText('Select project')[0]!);
 
     const grid = screen.getByTestId('virtual-card-grid');
-    grid.scrollTop = 13_000;
+    grid.scrollTop = Math.floor(100 / 3) * 265;
     fireEvent.scroll(grid);
     let target: HTMLElement | null = null;
     await waitFor(() => {
@@ -118,7 +118,7 @@ describe('DesignsTab virtualization interactions', () => {
 
     for (let index = 0; index < 12; index += 1) {
       fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' });
-      const expectedIndex = (index + 1) * 2;
+      const expectedIndex = (index + 1) * 3;
       await waitFor(() =>
         expect(
           document.activeElement?.closest('[data-card-index]'),

--- a/src/__tests__/DesignsTab.virtualization.test.tsx
+++ b/src/__tests__/DesignsTab.virtualization.test.tsx
@@ -153,7 +153,7 @@ describe('DesignsTab virtualization interactions', () => {
     );
     await waitFor(() =>
       expect(
-        document.querySelector('[data-card-index="1"] [tabindex="0"]'),
+        view.container.querySelector('[data-card-index="1"] [tabindex="0"]'),
       ).not.toBeNull(),
     );
   });

--- a/src/__tests__/VideoMode.library.test.tsx
+++ b/src/__tests__/VideoMode.library.test.tsx
@@ -60,7 +60,7 @@ describe('VideoMode project library', () => {
     expect(
       view.container.querySelector<HTMLElement>('[class*="auto-fill"]')
         ?.className,
-    ).toContain('22rem');
+    ).toContain('352px');
     const cards = () => [...view.container.querySelectorAll('article')];
     expect(view.container.querySelector('article video')).toHaveAttribute(
       'src',

--- a/src/__tests__/VideoMode.library.test.tsx
+++ b/src/__tests__/VideoMode.library.test.tsx
@@ -57,6 +57,10 @@ describe('VideoMode project library', () => {
 
     expect(await screen.findByText('Podcast Teaser')).toBeVisible();
     expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
+    expect(
+      view.container.querySelector<HTMLElement>('[class*="auto-fill"]')
+        ?.className,
+    ).toContain('22rem');
     const cards = () => [...view.container.querySelectorAll('article')];
     expect(view.container.querySelector('article video')).toHaveAttribute(
       'src',

--- a/src/app/pages/VideoMode/VideoProjectsLibrary.tsx
+++ b/src/app/pages/VideoMode/VideoProjectsLibrary.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Search } from 'lucide-react';
 
+import { RESPONSIVE_PROJECT_GRID_CLASS } from '@/components/library/responsive-project-grid';
 import { Button } from '@/components/ui/button';
 import { VideoFolderCard } from '@/components/video/VideoFolderCard';
 import { useLanguage } from '@/shared/providers/language-provider';
@@ -145,7 +146,7 @@ export function VideoProjectsLibrary({
       </div>
 
       {visibleProjects.length > 0 ? (
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        <div className={RESPONSIVE_PROJECT_GRID_CLASS}>
           {visibleProjects.map((project) => (
             <VideoFolderCard
               key={project.id}

--- a/src/components/design/tabs/DesignsTab.tsx
+++ b/src/components/design/tabs/DesignsTab.tsx
@@ -4,6 +4,11 @@ import { toast } from 'sonner';
 
 import { GalleryFilters } from '@/components/design/GalleryFilters';
 import {
+  PROJECT_CARD_MAX_WIDTH_PX,
+  PROJECT_CARD_MIN_WIDTH_PX,
+  RESPONSIVE_PROJECT_GRID_CLASS,
+} from '@/components/library/responsive-project-grid';
+import {
   VirtualCardGrid,
   type VirtualCardGridHandle,
 } from '@/components/library/VirtualCardGrid';
@@ -226,9 +231,9 @@ export function DesignsTab({
         <VirtualCardGrid
           items={filtered}
           getKey={(project) => project.id}
-          gridClassName="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3"
-          mediumBreakpoint={768}
-          largeBreakpoint={1280}
+          gridClassName={RESPONSIVE_PROJECT_GRID_CLASS}
+          minColumnWidth={PROJECT_CARD_MIN_WIDTH_PX}
+          maxColumnWidth={PROJECT_CARD_MAX_WIDTH_PX}
           rowEstimate={265}
           apiRef={gridApiRef}
           renderItem={(project, index) => (

--- a/src/components/library/VirtualCardGrid.tsx
+++ b/src/components/library/VirtualCardGrid.tsx
@@ -31,6 +31,12 @@ interface VirtualCardGridProps<T> {
   renderItem: (item: T, index: number) => ReactNode;
   /** Estimated row height in px; tune to the card's rendered height. */
   rowEstimate?: number;
+  /**
+   * Applied only below VIRTUALIZE_THRESHOLD (PlainGrid). Ignored once the
+   * list virtualizes — VirtualGrid derives its row grid from minColumnWidth
+   * / maxColumnWidth instead, so both must be passed for consistent
+   * responsive layout across the threshold.
+   */
   gridClassName?: string;
   mediumBreakpoint?: number;
   largeBreakpoint?: number;
@@ -92,6 +98,8 @@ function PlainGrid<T>({
   mediumBreakpoint = 640,
   largeBreakpoint = 1024,
   minColumnWidth,
+  // maxColumnWidth intentionally unused here — gridClassName's own
+  // [&>*]:max-w-[...] rule handles the max card width in plain mode.
   apiRef,
 }: VirtualCardGridProps<T>) {
   const gridRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/library/VirtualCardGrid.tsx
+++ b/src/components/library/VirtualCardGrid.tsx
@@ -17,6 +17,7 @@ import {
 import { useVirtualizer } from '@tanstack/react-virtual';
 
 const GRID_CLASS = 'grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3';
+const GRID_GAP_PX = 12;
 const VIRTUALIZE_THRESHOLD = 60;
 
 export interface VirtualCardGridHandle {
@@ -33,6 +34,8 @@ interface VirtualCardGridProps<T> {
   gridClassName?: string;
   mediumBreakpoint?: number;
   largeBreakpoint?: number;
+  minColumnWidth?: number;
+  maxColumnWidth?: number;
   getScrollElement?: () => HTMLElement | null;
   apiRef?: MutableRefObject<VirtualCardGridHandle | null>;
 }
@@ -45,6 +48,8 @@ export function VirtualCardGrid<T>({
   gridClassName = GRID_CLASS,
   mediumBreakpoint = 640,
   largeBreakpoint = 1024,
+  minColumnWidth,
+  maxColumnWidth,
   getScrollElement,
   apiRef,
 }: VirtualCardGridProps<T>) {
@@ -57,6 +62,8 @@ export function VirtualCardGrid<T>({
         gridClassName={gridClassName}
         mediumBreakpoint={mediumBreakpoint}
         largeBreakpoint={largeBreakpoint}
+        minColumnWidth={minColumnWidth}
+        maxColumnWidth={maxColumnWidth}
         apiRef={apiRef}
       />
     );
@@ -69,6 +76,8 @@ export function VirtualCardGrid<T>({
       rowEstimate={rowEstimate}
       mediumBreakpoint={mediumBreakpoint}
       largeBreakpoint={largeBreakpoint}
+      minColumnWidth={minColumnWidth}
+      maxColumnWidth={maxColumnWidth}
       getScrollElement={getScrollElement}
       apiRef={apiRef}
     />
@@ -82,6 +91,7 @@ function PlainGrid<T>({
   gridClassName = GRID_CLASS,
   mediumBreakpoint = 640,
   largeBreakpoint = 1024,
+  minColumnWidth,
   apiRef,
 }: VirtualCardGridProps<T>) {
   const gridRef = useRef<HTMLDivElement | null>(null);
@@ -96,6 +106,7 @@ function PlainGrid<T>({
           element.clientWidth,
           mediumBreakpoint,
           largeBreakpoint,
+          minColumnWidth,
         ),
       );
     update();
@@ -106,7 +117,7 @@ function PlainGrid<T>({
     const observer = new ResizeObserver(update);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [largeBreakpoint, mediumBreakpoint]);
+  }, [largeBreakpoint, mediumBreakpoint, minColumnWidth]);
 
   useEffect(() => {
     if (!apiRef) return;
@@ -139,7 +150,14 @@ function columnCountForWidth(
   width: number,
   mediumBreakpoint: number,
   largeBreakpoint: number,
+  minColumnWidth?: number,
 ) {
+  if (minColumnWidth) {
+    return Math.max(
+      1,
+      Math.floor((width + GRID_GAP_PX) / (minColumnWidth + GRID_GAP_PX)),
+    );
+  }
   if (width >= largeBreakpoint) return 3;
   if (width >= mediumBreakpoint) return 2;
   return 1;
@@ -152,6 +170,8 @@ function VirtualGrid<T>({
   rowEstimate,
   mediumBreakpoint = 640,
   largeBreakpoint = 1024,
+  minColumnWidth,
+  maxColumnWidth,
   getScrollElement,
   apiRef,
 }: VirtualCardGridProps<T> & { rowEstimate: number }) {
@@ -174,10 +194,16 @@ function VirtualGrid<T>({
     initialRect: { width: 900, height: 700 },
   });
 
-  const gridStyle = useMemo<CSSProperties>(
-    () => ({ gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))` }),
-    [columnCount],
-  );
+  const gridStyle = useMemo<CSSProperties>(() => {
+    const maxWidth = maxColumnWidth
+      ? columnCount * maxColumnWidth + (columnCount - 1) * GRID_GAP_PX
+      : undefined;
+    return {
+      gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+      maxWidth,
+      width: '100%',
+    };
+  }, [columnCount, maxColumnWidth]);
 
   useEffect(() => {
     const element = parentRef.current;
@@ -188,6 +214,7 @@ function VirtualGrid<T>({
           element.clientWidth,
           mediumBreakpoint,
           largeBreakpoint,
+          minColumnWidth,
         ),
       );
     update();
@@ -198,7 +225,7 @@ function VirtualGrid<T>({
     const observer = new ResizeObserver(update);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [largeBreakpoint, mediumBreakpoint]);
+  }, [largeBreakpoint, mediumBreakpoint, minColumnWidth]);
 
   useEffect(() => {
     if (!apiRef) return;

--- a/src/components/library/responsive-project-grid.ts
+++ b/src/components/library/responsive-project-grid.ts
@@ -1,5 +1,9 @@
 export const PROJECT_CARD_MIN_WIDTH_PX = 288;
 export const PROJECT_CARD_MAX_WIDTH_PX = 352;
 
+// Values below are pixel-literal to match PROJECT_CARD_MIN_WIDTH_PX /
+// PROJECT_CARD_MAX_WIDTH_PX and VirtualCardGrid's GRID_GAP_PX (12). rem-based
+// values here would drift from those JS-computed column counts whenever the
+// root font size isn't 16px, breaking virtualized rows and keyboard nav.
 export const RESPONSIVE_PROJECT_GRID_CLASS =
-  'grid grid-cols-[repeat(auto-fill,minmax(min(18rem,100%),1fr))] justify-items-start gap-3 [&>*]:w-full [&>*]:max-w-[22rem]';
+  'grid grid-cols-[repeat(auto-fill,minmax(min(288px,100%),1fr))] justify-items-start gap-[12px] [&>*]:w-full [&>*]:max-w-[352px]';

--- a/src/components/library/responsive-project-grid.ts
+++ b/src/components/library/responsive-project-grid.ts
@@ -1,0 +1,5 @@
+export const PROJECT_CARD_MIN_WIDTH_PX = 288;
+export const PROJECT_CARD_MAX_WIDTH_PX = 352;
+
+export const RESPONSIVE_PROJECT_GRID_CLASS =
+  'grid grid-cols-[repeat(auto-fill,minmax(min(18rem,100%),1fr))] justify-items-start gap-3 [&>*]:w-full [&>*]:max-w-[22rem]';


### PR DESCRIPTION
## Summary

Replace fixed three-column project layouts with responsive grids that adapt to available width while keeping cards within a readable max width.

## Changes

- Share an auto-fill/minmax grid contract between Design and Video project libraries.
- Use 288px minimum and 352px maximum card sizing.
- Keep virtualized Design keyboard navigation and row calculations aligned with responsive columns.
- Add regression coverage for responsive grid classes and updated virtualization behavior.

## Testing

- pnpm validate
- CI=1 node_modules/.bin/vitest run src/__tests__/DesignsTab.virtualization.test.tsx src/__tests__/DesignsTab.test.tsx src/__tests__/VideoMode.library.test.tsx --reporter=dot
- Chrome verification at /design and /video

## Breaking Changes

None.

## Migration Required

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated project and video libraries with responsive grids that automatically fill available space.
  * Improved card sizing and layout consistency across screen sizes, with columns adapting to available width.
  * Added maximum grid width and consistent left alignment for a cleaner browsing experience.

* **Bug Fixes**
  * Improved navigation and selection behavior in multi-column project grids.
  * Refined focus handling when removing items from project grids.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->