### PR TITLE
ci: disable automatic Claude PR review by default

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,8 @@ name: Claude - Diff-Aware PR Reviewer
 
 # ABOUT THIS WORKFLOW
 # - Purpose: Generate a thorough, diff-aware code review for PRs with inline comments and summary.
-# - Trigger: Manual via workflow_dispatch only (automatic pull_request trigger disabled by default).
+# - Trigger: Manual — workflow_dispatch, commenting "@review" on a PR, or adding the "review" label.
+#   (Automatic pull_request trigger on every open/sync is disabled by default — see the `on:` block.)
 # - Outputs: A single sticky summary comment (updated in-place) + optional inline comments + optional report artifact.
 # - Docs: https://github.com/anthropics/claude-code-action
 #
@@ -35,11 +36,16 @@ name: Claude - Diff-Aware PR Reviewer
 # - This workflow does not modify source code. It only posts comments and writes reports.
 
 on:
-  # Automatic pull_request trigger disabled by default. Uncomment the two
-  # lines below to restore auto-review on PR open/sync/reopen. Until then,
-  # run manually via workflow_dispatch (Actions tab or `gh workflow run`).
+  # Automatic pull_request trigger on every open/sync is disabled by default.
+  # Uncomment the two lines below to restore it. Until then, trigger a review
+  # by: workflow_dispatch (Actions tab or `gh workflow run`), commenting
+  # "@review" on the PR, or adding the "review" label.
   # pull_request:
   #   types: [opened, synchronize, reopened, ready_for_review, unlabeled]
+  pull_request:
+    types: [labeled]
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -79,21 +85,33 @@ permissions:
 # Prevent multiple reviews running simultaneously for the same PR
 # Cancels in-progress reviews when new commits are pushed
 concurrency:
-  group: pr-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  group: pr-review-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   review:
     runs-on: ubuntu-latest
-    # Skip for draft PRs, automated dependency update bots, and PRs with "skip AI review" label
-    # Trigger immediately when "skip AI review" label is removed
+    # Runs on: workflow_dispatch, adding the "review" label, or a
+    # collaborator commenting "@review" on the PR. Skips automated
+    # dependency-update bots and PRs carrying the "skip AI review" label.
     if: |
-      (github.event_name == 'workflow_dispatch' || !github.event.pull_request.draft) &&
       !contains(github.actor, 'dependabot') &&
       !contains(github.actor, 'renovate') &&
       (
-        (github.event.action == 'unlabeled' && github.event.label.name == 'skip AI review') ||
-        (github.event.action != 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'skip AI review'))
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'review' &&
+          !contains(github.event.pull_request.labels.*.name, 'skip AI review')
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request != null &&
+          contains(github.event.comment.body, '@review') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+          !contains(github.event.issue.labels.*.name, 'skip AI review')
+        )
       )
     steps:
       - name: Checkout repository
@@ -109,10 +127,14 @@ jobs:
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
           INPUT_GENERATE_REPORT: ${{ inputs.generate_report }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "number=$INPUT_PR_NUMBER" >> $GITHUB_OUTPUT
             echo "generate_report=$INPUT_GENERATE_REPORT" >> $GITHUB_OUTPUT
+          elif [ "$EVENT_NAME" = "issue_comment" ]; then
+            echo "number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+            echo "generate_report=false" >> $GITHUB_OUTPUT
           else
             echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
             echo "generate_report=false" >> $GITHUB_OUTPUT
@@ -169,8 +191,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # track_progress not supported for unlabeled events
-          track_progress: ${{ github.event.action != 'unlabeled' }}
+          track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude - Diff-Aware PR Reviewer
 
 # ABOUT THIS WORKFLOW
 # - Purpose: Generate a thorough, diff-aware code review for PRs with inline comments and summary.
-# - Trigger: Automatic on PR open/sync OR manual via workflow_dispatch.
+# - Trigger: Manual via workflow_dispatch only (automatic pull_request trigger disabled by default).
 # - Outputs: A single sticky summary comment (updated in-place) + optional inline comments + optional report artifact.
 # - Docs: https://github.com/anthropics/claude-code-action
 #
@@ -35,8 +35,11 @@ name: Claude - Diff-Aware PR Reviewer
 # - This workflow does not modify source code. It only posts comments and writes reports.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, unlabeled]
+  # Automatic pull_request trigger disabled by default. Uncomment the two
+  # lines below to restore auto-review on PR open/sync/reopen. Until then,
+  # run manually via workflow_dispatch (Actions tab or `gh workflow run`).
+  # pull_request:
+  #   types: [opened, synchronize, reopened, ready_for_review, unlabeled]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ name: Claude - Diff-Aware PR Reviewer
 # - Update the prompt sections to match your team's review style.
 # - Use track_progress: true for visual progress during long reviews.
 # - Override CLAUDE_MODEL via workflow_dispatch input or set in repository variables
-#   (defaults to claude-sonnet-4-5-20250929) https://platform.claude.com/docs/en/about-claude/models/overview
+#   (defaults to claude-sonnet-5) https://platform.claude.com/docs/en/about-claude/models/overview
 # - Enable extended thinking via workflow_dispatch input for deeper analysis (use_extended_thinking=true)
 # - Enable inline comments via workflow_dispatch input or repository variable (enable_inline_comments=true)
 #
@@ -52,7 +52,7 @@ on:
         description: Generate markdown report artifact (true/false)
         default: 'true'
       claude_model:
-        description: Claude model to use (e.g., claude-opus-4-5-20251101, https://platform.claude.com/docs/en/about-claude/models/overview)
+        description: Claude model to use (e.g., claude-opus-5, https://platform.claude.com/docs/en/about-claude/models/overview)
         required: false
       use_extended_thinking:
         description: Enable extended thinking for deeper analysis (true/false)
@@ -65,7 +65,7 @@ on:
 
 # Environment variables (can be overridden via workflow_dispatch or repository settings)
 env:
-  CLAUDE_MODEL: ${{ github.event.inputs.claude_model || vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
+  CLAUDE_MODEL: ${{ github.event.inputs.claude_model || vars.CLAUDE_MODEL || 'claude-sonnet-5' }}
   ENABLE_EXTENDED_THINKING: ${{ github.event.inputs.use_extended_thinking || vars.ENABLE_EXTENDED_THINKING || 'false' }}
   ENABLE_INLINE_COMMENTS: ${{ github.event.inputs.enable_inline_comments || vars.ENABLE_INLINE_COMMENTS || 'false' }}
 
@@ -164,7 +164,7 @@ jobs:
           chmod +x post-review.sh
 
       - name: Claude Code Review
-        uses: anthropics/claude-code-action@3ac52d0da9f8ec9ca7b4dc23bb477e36ef9c77a9 # v1
+        uses: anthropics/claude-code-action@3f854a8fb5146b39d5cbf8b57f70d80810e1366f # v1 (v1.0.198)
         env:
           GH_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
- Comment out the `pull_request` trigger on the Claude diff-aware PR reviewer workflow (`.github/workflows/claude-code-review.yml`) so it no longer auto-runs on every PR open/sync/reopen.
- Trigger is left commented (not deleted) so re-enabling is a two-line uncomment.
- The reviewer is still available on demand via `workflow_dispatch` (Actions tab or `gh workflow run`).
- The separate `@claude` mention-triggered assistant (`.github/workflows/claude.yml`) is untouched.

## Why
Comparing CodeRabbit vs. Claude's automatic PR review on recent PRs (#7, #8) to decide which to keep running by default. Disabling auto-run for now while leaving manual invocation intact.

## Testing
- N/A — workflow-trigger-only change, no source code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-in AI reviews triggered manually, by applying the “review” label, or by commenting “@review” on a pull request.
  - Added support for initiating reviews through issue comments.

- **Improvements**
  - Updated the default review model and progress tracking behavior.
  - Improved review handling for concurrent requests and supported collaborator permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->