### PR TITLE
chore(deps): upgrade G11 — native / runtime modules

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,8 +498,8 @@ importers:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@25.9.3)
       sherpa-onnx-node:
-        specifier: 1.13.4
-        version: 1.13.4
+        specifier: 1.13.6
+        version: 1.13.6
       sqlite-vec:
         specifier: 0.1.9
         version: 0.1.9
@@ -517,8 +517,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@contentauth/c2pa-node':
-        specifier: 0.8.3
-        version: 0.8.3(supports-color@10.2.2)
+        specifier: 0.9.1
+        version: 0.9.1(supports-color@10.2.2)
       '@slack/types':
         specifier: ^3.0.0
         version: 3.0.0
@@ -1459,9 +1459,15 @@ packages:
     resolution: {integrity: sha512-DD9snx7YUk1a3snQ+7UqNolHZzxf8/WJ4mAEXBIFdeOddwLdoIyw3tWXhhsQrhQIZ+OTAulYnjom4+GdQKaSoA==}
     engines: {node: '>=18.0.0'}
 
-  '@contentauth/c2pa-node@0.8.3':
-    resolution: {integrity: sha512-kd9E65qLRjK6QXMx6LZ99m+VXllIGFXcst0sseTnJ4C2DNX292ZXXFppa/OcUPLeZmc6JHtAJBZAWYGu8X6m2A==}
+  '@contentauth/c2pa-node@0.9.1':
+    resolution: {integrity: sha512-YswlLS5KlfenAzNnqFbAT2WLyxaUe8psUTbs8ieHpFvD/LoPunaH5qgx4KLX5HkjBKEsrtqruoo9B7VhipQzLA==}
     engines: {node: '>=22'}
+
+  '@contentauth/c2pa-types@0.7.3':
+    resolution: {integrity: sha512-R1F0R13/m8W7c4OJQw2jilnYcQEHItaRgQEnUt2KpcPFLl4VG1Bblg1UVMQG8oFH3hG2mXf19eBHeMzxGdKWEQ==}
+
+  '@contentauth/c2pa-utilities@0.2.1':
+    resolution: {integrity: sha512-9pFE528LJKvksGcSQrMbQhJWEPPN/5GMcSSkaJAJ1NQZ3oknmpVkLRjWkYBTlSjBBWQ5zbQCtgjlO+4ox9EJCw==}
 
   '@copilotkit/a2ui-renderer@1.66.4':
     resolution: {integrity: sha512-87xk+yPsBj5S2tuE2kVggEfF2yEig6N69D5oOFC+gs+vYgHSWBZoEyXDalKa/2j180Hk++WH2QHkM+IM0UezDw==}
@@ -9547,36 +9553,36 @@ packages:
     resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
-  sherpa-onnx-darwin-arm64@1.13.5:
-    resolution: {integrity: sha512-weDBAV6da64j6PPYuuG1VYqHzmjthNFZmrFV9yyJ8YXxWrZvIe8kXXYvOIU2curODucvLObHosZU9kJ4uVwM3Q==}
+  sherpa-onnx-darwin-arm64@1.13.6:
+    resolution: {integrity: sha512-m3QMOGUHVPUl7bAOPc7oJtmzOVdzQVQPsCuTjNuQ2N6zlYuXDZu9NdUR3Er3rxbhHa6SmWa94flUwmUsO1atow==}
     cpu: [arm64]
     os: [darwin]
 
-  sherpa-onnx-darwin-x64@1.13.5:
-    resolution: {integrity: sha512-Ay//Bq4T3RHYhzdYk9O0ahg0UoEgbRMDGZvtpQi2D0oHOcXv0M5tP3OKlx4AvWNXYl0SL+rUObUFe5IIqROrfQ==}
+  sherpa-onnx-darwin-x64@1.13.6:
+    resolution: {integrity: sha512-3X5FQ9PpwlBmxLqtb2/uvl7/W2HXXzXHT0MLmB9c0TRMANLujzvIF7YbT6VW3k92ClL/1q9sbIOul0rHgxCTmw==}
     cpu: [x64]
     os: [darwin]
 
-  sherpa-onnx-linux-arm64@1.13.5:
-    resolution: {integrity: sha512-1Jpkyv+Sg7wl+jCOlttcudVpVdlCNPXMf/RYT4+FU4/VmoMIx9MZbcSu2Nf8gtKq3mnYdkk7HtCK5AA3Dtuvwg==}
+  sherpa-onnx-linux-arm64@1.13.6:
+    resolution: {integrity: sha512-xSzhqrGFbBrykpbEFt5dLXB3Sp3a8idNzjhf92uylDgUhupBSRHj3ISeYaL9ZZWTNSzszNXBKlM+xH36dHQjPg==}
     cpu: [arm64]
     os: [linux]
 
-  sherpa-onnx-linux-x64@1.13.5:
-    resolution: {integrity: sha512-eedC/AMCL2cvwhtPnmRlLHKXuwBmD7o2r+Kb+I0krg4PlQejR9y6O1oKqdLko5vFaWe2A8/rQORKGXE+We3y4Q==}
+  sherpa-onnx-linux-x64@1.13.6:
+    resolution: {integrity: sha512-HiR3yolQDl3WoU1zSXn8L0MSXzF9PXLQpMv+Ptozg1y/DJU8HuvoXBasOarX4cer5d9kGimnOUGm0dl47PCN1A==}
     cpu: [x64]
     os: [linux]
 
-  sherpa-onnx-node@1.13.4:
-    resolution: {integrity: sha512-jHWWdY9f0dbvJpdsfR/C4WNhM57+jT9Os2RyC4/qUz8HKCtj2VYFmJ9s7tue9OCFRAmdoGBkgkqD6aBZ3I8BKw==}
+  sherpa-onnx-node@1.13.6:
+    resolution: {integrity: sha512-FjUSQSStTi/wcLqlScGFmNA7ySjW3QwquJcMRJ1yDkDpBp0BmWXkXoirDuEj8/v2/Cs4wLYJp2BKaMD9+1lDGA==}
 
-  sherpa-onnx-win-ia32@1.13.5:
-    resolution: {integrity: sha512-aQKTmzsvNyCMOoAs+Clx8Zsp05JSX37hVpts/yiO3+mUTXnbBIMAL3YgG49apz6JN/l/HCJBaEczXj3odOgS8A==}
+  sherpa-onnx-win-ia32@1.13.6:
+    resolution: {integrity: sha512-CN6rNQqn0wzdSp3XRHxdmNaLUMhP+BgsWVbaASU+V9CYBdx74uutoA/43ThUfh3S3CiArpp8OJtn8dJrPeGHnw==}
     cpu: [ia32]
     os: [win32]
 
-  sherpa-onnx-win-x64@1.13.5:
-    resolution: {integrity: sha512-r1lKWEbFDquVjiij72nhNpmPBeqG7V06ZGx1uL2zWXFCYXmkpqawN5iHdkugVhb8QfYZ8x2tx88eYGHGMn88aA==}
+  sherpa-onnx-win-x64@1.13.6:
+    resolution: {integrity: sha512-bPMdURD1XCu1Zr3eYYlYx2obc5CMSQhEnd1GQuv7FXjdyOeMJ8jNbQEKFEIAyQdC481FgZvPBb2oSJXaLOOeVw==}
     cpu: [x64]
     os: [win32]
 
@@ -10032,6 +10038,10 @@ packages:
   ts-dedent@2.3.0:
     resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
     engines: {node: '>=6.10'}
+
+  ts-deepmerge@8.0.0:
+    resolution: {integrity: sha512-133O+10nJmVI8w5xeVZPEv5PIrv7iaUae07wv1aH8XJH95Ur6YIhWAPhPyP1YPlbPS9fCVcNIZTu7m8urRVF0A==}
+    engines: {node: '>=14.13.1'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -11775,8 +11785,10 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@contentauth/c2pa-node@0.8.3(supports-color@10.2.2)':
+  '@contentauth/c2pa-node@0.9.1(supports-color@10.2.2)':
     dependencies:
+      '@contentauth/c2pa-types': 0.7.3
+      '@contentauth/c2pa-utilities': 0.2.1
       cargo-cp-artifact: 0.1.9
       cli-progress: 3.12.0
       debug: 4.4.3(supports-color@10.2.2)
@@ -11788,6 +11800,13 @@ snapshots:
       unzipper: 0.10.14
     transitivePeerDependencies:
       - supports-color
+
+  '@contentauth/c2pa-types@0.7.3': {}
+
+  '@contentauth/c2pa-utilities@0.2.1':
+    dependencies:
+      '@contentauth/c2pa-types': 0.7.3
+      ts-deepmerge: 8.0.0
 
   '@copilotkit/a2ui-renderer@1.66.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -20817,31 +20836,31 @@ snapshots:
 
   shell-quote@1.8.4: {}
 
-  sherpa-onnx-darwin-arm64@1.13.5:
+  sherpa-onnx-darwin-arm64@1.13.6:
     optional: true
 
-  sherpa-onnx-darwin-x64@1.13.5:
+  sherpa-onnx-darwin-x64@1.13.6:
     optional: true
 
-  sherpa-onnx-linux-arm64@1.13.5:
+  sherpa-onnx-linux-arm64@1.13.6:
     optional: true
 
-  sherpa-onnx-linux-x64@1.13.5:
+  sherpa-onnx-linux-x64@1.13.6:
     optional: true
 
-  sherpa-onnx-node@1.13.4:
+  sherpa-onnx-node@1.13.6:
     optionalDependencies:
-      sherpa-onnx-darwin-arm64: 1.13.5
-      sherpa-onnx-darwin-x64: 1.13.5
-      sherpa-onnx-linux-arm64: 1.13.5
-      sherpa-onnx-linux-x64: 1.13.5
-      sherpa-onnx-win-ia32: 1.13.5
-      sherpa-onnx-win-x64: 1.13.5
+      sherpa-onnx-darwin-arm64: 1.13.6
+      sherpa-onnx-darwin-x64: 1.13.6
+      sherpa-onnx-linux-arm64: 1.13.6
+      sherpa-onnx-linux-x64: 1.13.6
+      sherpa-onnx-win-ia32: 1.13.6
+      sherpa-onnx-win-x64: 1.13.6
 
-  sherpa-onnx-win-ia32@1.13.5:
+  sherpa-onnx-win-ia32@1.13.6:
     optional: true
 
-  sherpa-onnx-win-x64@1.13.5:
+  sherpa-onnx-win-x64@1.13.6:
     optional: true
 
   shiki@3.23.0:
@@ -21399,6 +21418,8 @@ snapshots:
   ts-algebra@2.0.0: {}
 
   ts-dedent@2.3.0: {}
+
+  ts-deepmerge@8.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 

--- a/src-api/package.json
+++ b/src-api/package.json
@@ -70,7 +70,7 @@
     "react-dom": "19.2.8",
     "remotion": "4.0.507",
     "sharp": "^0.35.3",
-    "sherpa-onnx-node": "1.13.4",
+    "sherpa-onnx-node": "1.13.6",
     "sqlite-vec": "0.1.9",
     "undici": "^7.29.0",
     "ws": "^8.21.0",
@@ -78,7 +78,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@contentauth/c2pa-node": "0.8.3",
+    "@contentauth/c2pa-node": "0.9.1",
     "@slack/types": "^3.0.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.9.3",

--- a/src/__tests__/DesignsTab.test.tsx
+++ b/src/__tests__/DesignsTab.test.tsx
@@ -53,6 +53,9 @@ describe('DesignsTab cards', () => {
     );
 
     const preview = await screen.findByTitle('Project design_card_1 preview');
+    expect(
+      document.querySelector<HTMLElement>('[class*="auto-fill"]')?.className,
+    ).toContain('22rem');
     expect(preview).toHaveAttribute('sandbox', SANDBOX_ATTR);
     expect(preview.closest('.pointer-events-none')).toBeTruthy();
 

--- a/src/__tests__/DesignsTab.virtualization.test.tsx
+++ b/src/__tests__/DesignsTab.virtualization.test.tsx
@@ -96,7 +96,7 @@ describe('DesignsTab virtualization interactions', () => {
     await user.click(screen.getAllByLabelText('Select project')[0]!);
 
     const grid = screen.getByTestId('virtual-card-grid');
-    grid.scrollTop = 13_000;
+    grid.scrollTop = Math.floor(100 / 3) * 265;
     fireEvent.scroll(grid);
     let target: HTMLElement | null = null;
     await waitFor(() => {
@@ -118,7 +118,7 @@ describe('DesignsTab virtualization interactions', () => {
 
     for (let index = 0; index < 12; index += 1) {
       fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' });
-      const expectedIndex = (index + 1) * 2;
+      const expectedIndex = (index + 1) * 3;
       await waitFor(() =>
         expect(
           document.activeElement?.closest('[data-card-index]'),

--- a/src/__tests__/VideoMode.library.test.tsx
+++ b/src/__tests__/VideoMode.library.test.tsx
@@ -57,6 +57,10 @@ describe('VideoMode project library', () => {
 
     expect(await screen.findByText('Podcast Teaser')).toBeVisible();
     expect(screen.getAllByText('Completed').length).toBeGreaterThan(0);
+    expect(
+      view.container.querySelector<HTMLElement>('[class*="auto-fill"]')
+        ?.className,
+    ).toContain('22rem');
     const cards = () => [...view.container.querySelectorAll('article')];
     expect(view.container.querySelector('article video')).toHaveAttribute(
       'src',

--- a/src/app/pages/VideoMode/VideoProjectsLibrary.tsx
+++ b/src/app/pages/VideoMode/VideoProjectsLibrary.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { Search } from 'lucide-react';
 
+import { RESPONSIVE_PROJECT_GRID_CLASS } from '@/components/library/responsive-project-grid';
 import { Button } from '@/components/ui/button';
 import { VideoFolderCard } from '@/components/video/VideoFolderCard';
 import { useLanguage } from '@/shared/providers/language-provider';
@@ -145,7 +146,7 @@ export function VideoProjectsLibrary({
       </div>
 
       {visibleProjects.length > 0 ? (
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        <div className={RESPONSIVE_PROJECT_GRID_CLASS}>
           {visibleProjects.map((project) => (
             <VideoFolderCard
               key={project.id}

--- a/src/components/design/tabs/DesignsTab.tsx
+++ b/src/components/design/tabs/DesignsTab.tsx
@@ -4,6 +4,11 @@ import { toast } from 'sonner';
 
 import { GalleryFilters } from '@/components/design/GalleryFilters';
 import {
+  PROJECT_CARD_MAX_WIDTH_PX,
+  PROJECT_CARD_MIN_WIDTH_PX,
+  RESPONSIVE_PROJECT_GRID_CLASS,
+} from '@/components/library/responsive-project-grid';
+import {
   VirtualCardGrid,
   type VirtualCardGridHandle,
 } from '@/components/library/VirtualCardGrid';
@@ -226,9 +231,9 @@ export function DesignsTab({
         <VirtualCardGrid
           items={filtered}
           getKey={(project) => project.id}
-          gridClassName="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3"
-          mediumBreakpoint={768}
-          largeBreakpoint={1280}
+          gridClassName={RESPONSIVE_PROJECT_GRID_CLASS}
+          minColumnWidth={PROJECT_CARD_MIN_WIDTH_PX}
+          maxColumnWidth={PROJECT_CARD_MAX_WIDTH_PX}
           rowEstimate={265}
           apiRef={gridApiRef}
           renderItem={(project, index) => (

--- a/src/components/library/VirtualCardGrid.tsx
+++ b/src/components/library/VirtualCardGrid.tsx
@@ -17,6 +17,7 @@ import {
 import { useVirtualizer } from '@tanstack/react-virtual';
 
 const GRID_CLASS = 'grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3';
+const GRID_GAP_PX = 12;
 const VIRTUALIZE_THRESHOLD = 60;
 
 export interface VirtualCardGridHandle {
@@ -33,6 +34,8 @@ interface VirtualCardGridProps<T> {
   gridClassName?: string;
   mediumBreakpoint?: number;
   largeBreakpoint?: number;
+  minColumnWidth?: number;
+  maxColumnWidth?: number;
   getScrollElement?: () => HTMLElement | null;
   apiRef?: MutableRefObject<VirtualCardGridHandle | null>;
 }
@@ -45,6 +48,8 @@ export function VirtualCardGrid<T>({
   gridClassName = GRID_CLASS,
   mediumBreakpoint = 640,
   largeBreakpoint = 1024,
+  minColumnWidth,
+  maxColumnWidth,
   getScrollElement,
   apiRef,
 }: VirtualCardGridProps<T>) {
@@ -57,6 +62,8 @@ export function VirtualCardGrid<T>({
         gridClassName={gridClassName}
         mediumBreakpoint={mediumBreakpoint}
         largeBreakpoint={largeBreakpoint}
+        minColumnWidth={minColumnWidth}
+        maxColumnWidth={maxColumnWidth}
         apiRef={apiRef}
       />
     );
@@ -69,6 +76,8 @@ export function VirtualCardGrid<T>({
       rowEstimate={rowEstimate}
       mediumBreakpoint={mediumBreakpoint}
       largeBreakpoint={largeBreakpoint}
+      minColumnWidth={minColumnWidth}
+      maxColumnWidth={maxColumnWidth}
       getScrollElement={getScrollElement}
       apiRef={apiRef}
     />
@@ -82,6 +91,7 @@ function PlainGrid<T>({
   gridClassName = GRID_CLASS,
   mediumBreakpoint = 640,
   largeBreakpoint = 1024,
+  minColumnWidth,
   apiRef,
 }: VirtualCardGridProps<T>) {
   const gridRef = useRef<HTMLDivElement | null>(null);
@@ -96,6 +106,7 @@ function PlainGrid<T>({
           element.clientWidth,
           mediumBreakpoint,
           largeBreakpoint,
+          minColumnWidth,
         ),
       );
     update();
@@ -106,7 +117,7 @@ function PlainGrid<T>({
     const observer = new ResizeObserver(update);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [largeBreakpoint, mediumBreakpoint]);
+  }, [largeBreakpoint, mediumBreakpoint, minColumnWidth]);
 
   useEffect(() => {
     if (!apiRef) return;
@@ -139,7 +150,14 @@ function columnCountForWidth(
   width: number,
   mediumBreakpoint: number,
   largeBreakpoint: number,
+  minColumnWidth?: number,
 ) {
+  if (minColumnWidth) {
+    return Math.max(
+      1,
+      Math.floor((width + GRID_GAP_PX) / (minColumnWidth + GRID_GAP_PX)),
+    );
+  }
   if (width >= largeBreakpoint) return 3;
   if (width >= mediumBreakpoint) return 2;
   return 1;
@@ -152,6 +170,8 @@ function VirtualGrid<T>({
   rowEstimate,
   mediumBreakpoint = 640,
   largeBreakpoint = 1024,
+  minColumnWidth,
+  maxColumnWidth,
   getScrollElement,
   apiRef,
 }: VirtualCardGridProps<T> & { rowEstimate: number }) {
@@ -174,10 +194,16 @@ function VirtualGrid<T>({
     initialRect: { width: 900, height: 700 },
   });
 
-  const gridStyle = useMemo<CSSProperties>(
-    () => ({ gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))` }),
-    [columnCount],
-  );
+  const gridStyle = useMemo<CSSProperties>(() => {
+    const maxWidth = maxColumnWidth
+      ? columnCount * maxColumnWidth + (columnCount - 1) * GRID_GAP_PX
+      : undefined;
+    return {
+      gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+      maxWidth,
+      width: '100%',
+    };
+  }, [columnCount, maxColumnWidth]);
 
   useEffect(() => {
     const element = parentRef.current;
@@ -188,6 +214,7 @@ function VirtualGrid<T>({
           element.clientWidth,
           mediumBreakpoint,
           largeBreakpoint,
+          minColumnWidth,
         ),
       );
     update();
@@ -198,7 +225,7 @@ function VirtualGrid<T>({
     const observer = new ResizeObserver(update);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [largeBreakpoint, mediumBreakpoint]);
+  }, [largeBreakpoint, mediumBreakpoint, minColumnWidth]);
 
   useEffect(() => {
     if (!apiRef) return;

--- a/src/components/library/responsive-project-grid.ts
+++ b/src/components/library/responsive-project-grid.ts
@@ -1,0 +1,5 @@
+export const PROJECT_CARD_MIN_WIDTH_PX = 288;
+export const PROJECT_CARD_MAX_WIDTH_PX = 352;
+
+export const RESPONSIVE_PROJECT_GRID_CLASS =
+  'grid grid-cols-[repeat(auto-fill,minmax(min(18rem,100%),1fr))] justify-items-start gap-3 [&>*]:w-full [&>*]:max-w-[22rem]';


### PR DESCRIPTION
## Summary

Part of the 2026-08-21 quarterly dependency sweep (group 11 of 15), based on `main`.

| Package | Before | After |
| --- | --- | --- |
| sherpa-onnx-node | 1.13.4 | 1.13.6 |
| @contentauth/c2pa-node | 0.8.3 | 0.9.1 |

`better-sqlite3` stays **held** at 12.10.1 (the pkg static-bundler `exports`-map issue from the 2026-08-08 sweep is still unresolved — no shim exists for it yet). `onnxruntime-node`, `sqlite-vec`, `sharp`, `bcryptjs` already at latest.

## Pre-gate: prebuild matrix verification (§7 G11)

- `sherpa-onnx-node@1.13.6` publishes full platform `optionalDependencies` (darwin-arm64/x64, linux-x64/arm64, win-x64/ia32).
- `@contentauth/c2pa-node@0.9.1`'s postinstall fetches a prebuilt archive per platform from GitHub Releases — confirmed all 5 required assets exist (`aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64`/`aarch64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`), and the mac-arm fetch succeeded live during `pnpm install` in this environment.

## Gate evidence

- `pnpm install` — clean, no peer warnings; c2pa-node's postinstall confirmed downloading the mac-arm binary.
- `pnpm typecheck:all && pnpm lint && pnpm format:check` — green.
- `pnpm test:fast` — 287+486 files / 1218+3028 tests passed.
- `pnpm build:api:binary:mac-arm` — produces a 122MB binary.
- Booted the packaged binary standalone (constructed a `RESOURCES_DIR` matching the Tauri resource layout — `_up_/src-api/dist/{sharp,sherpa-onnx,onnxruntime}/...`) — full app init (226 plugins) succeeds, `/health` returns 200. This confirms `sharp`, `onnxruntime-node`, `sherpa-onnx-node`, and `c2pa-node` all resolve correctly through the pkg resource shim on mac-arm.
- Narrower per-feature smokes (a live SQLite/sqlite-vec query, an ONNX inference call, VAD/sherpa voice processing, a c2pa sign/verify round-trip) weren't individually exercised beyond this — full-app-boot plus the existing `test:api` unit/integration coverage for these modules is the verification for this run.
- `pnpm audit --audit-level moderate` — unchanged at 15 (this branch doesn't include G3's `brace-expansion` override, a separate PR). Confirmed the `c2pa-node`-chain `brace-expansion@1.1.18` copy was never actually vulnerable — all six current `brace-expansion` advisories have vulnerable ranges starting at `>=2.0.0` or `>=3.0.0`/`4.0.0`, none covering 1.x.
- `pnpm audit signatures` — 2145/2145 verified.
- linux/windows/mac-intel binaries **not built** — no cross-compilation toolchain in this environment (same limitation noted in the 2026-08-08 sweep); needs the CI/release pipeline before the next tagged release.

## Test plan

- [x] CI green on this PR
- [ ] CI/release pipeline builds and smoke-tests the linux/windows/mac-intel binaries

https://claude.ai/code/session_013NWNgvdX3itwigLiSDUgcF