### PR TITLE
chore: release v26.8.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+## [26.8.27] - 2026-08-27
+
+Maintenance release.
+
 ## [26.8.25] - 2026-08-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neumar",
-  "version": "26.8.25",
+  "version": "26.8.27",
   "private": true,
   "homepage": "https://github.com/bravew/Neumar#readme",
   "bugs": {

--- a/src-api/package.json
+++ b/src-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neumar-api",
-  "version": "26.8.25",
+  "version": "26.8.27",
   "type": "module",
   "scripts": {
     "predev": "pnpm --filter @neumar/video-ir build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neumar"
-version = "26.8.25"
+version = "26.8.27"
 description = "A desktop AI agent application that works tirelessly like a bull and horse to execute tasks through natural language."
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Neumar",
-  "version": "26.8.25",
+  "version": "26.8.27",
   "identifier": "ai.neumar",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- Bump version to 26.8.27 across package.json, src-api/package.json, tauri.conf.json, and Cargo.toml
- Add the v26.8.27 maintenance release entry to CHANGELOG.md

## Test plan
- pnpm release:build-and-publish:mac-arm
- pnpm validate: blocked by two existing type errors in src/__tests__/video/timelineMath.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 26.8.27 as a maintenance update.
  * Updated the application version information across supported components.
  * Added the release to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->