### PR TITLE
ci: unbreak the review workflow, and gate workflow files on actionlint

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -444,7 +444,7 @@ jobs:
             - Path traversal: file operations that don't validate against workspace boundaries
             - Command injection: shell commands constructed from user input without sanitization
             - SQL injection: raw SQL queries with string interpolation instead of parameterized queries
-            - GitHub Actions: `${{ }}` interpolated directly into a `run:` block — must go through an `env:` block
+            - GitHub Actions: workflow expressions interpolated directly into a `run:` block — values must be passed through an `env:` block instead
             - Sensitive data in URLs or query parameters
 
             ### Performance

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,77 @@
+name: Workflow Lint
+
+# ABOUT THIS WORKFLOW
+# - Purpose: Validate the workflow files themselves — expressions, schema, contexts, action refs.
+# - Trigger: Any PR or push to main that touches .github/workflows/**, plus workflow_dispatch.
+#
+# WHY THIS EXISTS
+# - GitHub validates workflow expressions only when it dispatches a run, and an invalid file
+#   fails silently: the workflow simply stops firing. No queued job, no failing check, no
+#   annotation on the PR that introduced it — the only trace is a jobless failed run against
+#   the merge commit saying "This run likely failed because of a workflow file issue".
+# - That took the PR reviewer offline in 93555dd: a literal `$`+`{{ }}` token written inside a
+#   prompt string parsed as an empty expression and invalidated the whole file. YAML linting
+#   does not catch this, because the file is valid YAML — the problem is the expression grammar.
+# - actionlint parses expressions the way GitHub does, so it catches that class before merge.
+#
+# SHELLCHECK
+# - actionlint can also run shellcheck over every `run:` block. It is disabled here because the
+#   existing workflows carry 38 findings (all SC2086 info-level, mostly in build.yml and
+#   update-cask.yml), and a gate that is red on arrival gets ignored rather than fixed.
+# - To enable once those are cleaned: drop `-shellcheck=` below and install shellcheck on the
+#   runner (ubuntu-latest ships with it).
+#
+# UPGRADING ACTIONLINT
+# - Bump ACTIONLINT_VERSION and replace ACTIONLINT_SHA256 with the matching linux_amd64 entry
+#   from actionlint_<version>_checksums.txt on the release page. The checksum is verified before
+#   the binary runs, so a bumped version with a stale hash fails loudly rather than silently
+#   running unverified code.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: workflow-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Run actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+
+          TARBALL="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL --retry 3 --retry-delay 2 -o "$TARBALL" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${TARBALL}"
+
+          # Verify before executing — the binary is fetched at runtime, so the checksum is
+          # what pins it, the way a SHA pins a third-party action.
+          echo "${ACTIONLINT_SHA256}  ${TARBALL}" | sha256sum -c -
+
+          tar -xzf "$TARBALL" actionlint
+          chmod +x actionlint
+
+          ./actionlint -version
+          # -shellcheck= / -pyflakes= disable the embedded linters; see SHELLCHECK above.
+          ./actionlint -shellcheck= -pyflakes= -color


### PR DESCRIPTION
**The PR reviewer has been offline since 93555dd was merged.** Two commits: the unblock, and the check that would have caught it.

## What broke

#31 added this line to the review prompt's security checklist, written with the real token:

> - GitHub Actions: `` `${…}` `` interpolated directly into a `run:` block — must go through an `env:` block

GitHub parses expression braces **anywhere in the workflow file**, including inside a prompt string. It hit an empty expression and rejected the file:

```
.github/workflows/claude-code-review.yml:293: unexpected end of input while parsing
variable access, function call, null, bool, int, float or string [expression]
```

A rule about expression interpolation, broken by expression interpolation. `fadbe37` rewords it to describe the pattern instead of quoting it.

## Why it produced no signal

An invalid workflow doesn't fail loudly — it just stops firing. Commenting `@review` on #29 after the merge created **no run at all**: no queued job, no failing check, no annotation on the PR that introduced it. The only trace was a jobless failed run against the merge commit:

```
X main .github/workflows/claude-code-review.yml · 34354290262
X This run likely failed because of a workflow file issue.
```

That silence is the actual hazard, which is what the second commit addresses.

## The gate (`472eeac`)

Nothing in this repo could have caught this. YAML linting passes — the file *is* valid YAML; the problem is the expression grammar, which GitHub only parses at dispatch time. My own pre-merge check was PyYAML, and it was green.

`actionlint` parses expressions the way GitHub does. Verified against the real bug rather than assumed:

```
$ actionlint -shellcheck= -pyflakes=          # with the token reintroduced
claude-code-review.yml:293:10746: unexpected end of input... [expression]
exit=1

$ actionlint -shellcheck= -pyflakes=          # with it fixed
exit=0    # all seven workflows clean
```

Runs on any PR or push to `main` touching `.github/workflows/**`. It couldn't live in `ci.yml` — those jobs are gated to release branches, so they wouldn't fire on a workflow edit.

**Shellcheck integration is off.** actionlint can also shellcheck every `run:` block, but the existing workflows carry 38 findings (all `SC2086` info-level, concentrated in `build.yml` and `update-cask.yml`). A gate that's red on arrival gets ignored rather than fixed, so it ships green with a header comment on how to enable it once those are cleaned. Worth doing separately.

**On pinning:** actionlint is fetched at runtime, so the `sha256` is what pins it — the same role a commit SHA plays for a third-party action. A version bump with a stale hash fails the checksum rather than silently running unverified code. URL, checksum, and archive layout were each verified before committing.

## Verification

- The expression fix and the gate were each tested against the real failure, not just reasoned about
- All seven workflows clean under actionlint
- Not verified on a runner, because it can't be — no review can run until this lands

This PR's own `Workflow Lint` check is the first live exercise of the gate.

https://claude.ai/code/session_01MKeQK5rfizpX6EhzysELCR