### PR TITLE
ci: stop the guard rejecting reviews the comment tool sanitized

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,11 +45,15 @@ name: Claude - Diff-Aware PR Reviewer
 #   each run, so the PR conversation keeps only the current review expanded.
 #
 # COMPLETION GUARD
-# - Claude must write the summary to review.md AND end the posted comment with the
-#   <!-- claude-review-complete --> marker.
-# - The guard checks the PR itself, not the runner's disk: it looks for this run's claude[bot]
-#   comment carrying that marker. A local review.md proves only that Claude started writing —
-#   run 34312666877 ended with a summary it never posted.
+# - A run counts as complete only when both are true: review.md ends with the
+#   <!-- claude-review-complete --> marker (Claude finished writing), and this run's claude[bot]
+#   comment contains review.md's longest line (what it wrote reached the PR). Neither alone is
+#   enough — run 34312666877 ended with a summary it never posted.
+# - The marker is checked on the FILE, never on the comment: update_claude_comment strips HTML
+#   comments from the body it posts. Run 34356058557 posted a complete review, byte-identical to
+#   review.md except the stripped marker, and an earlier version of this guard rejected it.
+#   GitHub preserves HTML comments (CodeRabbit's comments keep five) — the sanitizing is the
+#   action's, so the marker lives where it survives and the comment is matched on visible text.
 # - "This run's comment" is identified two independent ways — absent from the pre-run comment
 #   snapshot, or stamped with the run id — so neither an action version that reformats tracking
 #   comments nor a missing snapshot can make the guard fail closed on every run.
@@ -487,7 +491,9 @@ jobs:
                  - 🔒 Security: Tauri capabilities, credential exposure, injection risks (or "No issues")
                  - 🌐 i18n: Missing translations in any locale (or "All locales updated")
                - **Coverage**: which files you reviewed and which you did not get to
-               - The literal marker `<!-- claude-review-complete -->` as the final line
+               - The literal marker `<!-- claude-review-complete -->` as review.md's final line.
+                 It marks the file as finished. The comment tool strips HTML comments, so it
+                 will not appear in the posted comment — that is expected, do not work around it.
             2. Post that exact content with `mcp__github_comment__update_claude_comment`.
 
             If you only managed a partial review, post it anyway with a `⚠️ Partial review` heading
@@ -558,7 +564,7 @@ jobs:
             --max-turns ${{ env.REVIEW_MAX_TURNS }}
             ${{ env.ENABLE_EXTENDED_THINKING == 'true' && '--thinking=enabled' || '' }}
             --allowedTools Read,Glob,Grep,mcp__github_comment__update_claude_comment,Bash(gh pr view:*),Bash(gh pr checks:*),Bash(cat CLAUDE.md),Write(review.md),Edit(review.md),Write(reports/*),Bash(mkdir -p reports)${{ env.ENABLE_INLINE_COMMENTS == 'true' && ',mcp__github_inline_comment__create_inline_comment' || '' }}
-            --append-system-prompt "You are a senior engineer reviewing application (React 19 + Hono + Tauri 2 + Claude Agent SDK). Flag bugs, security issues, performance problems, and convention violations. Be direct and concise - no compliments, no filler. SINGLE AGENT: subagents and the Task tool are unavailable — never plan parallel passes, work sequentially. DIFF: read pr-files.txt then pr-diff.patch from disk; never run 'gh pr diff' (HTTP 406 on large PRs). COMPLETION: you MUST write review.md and post it via mcp__github_comment__update_claude_comment before your turn budget runs out, ending the body with '<!-- claude-review-complete -->'; a partial review beats no review. DUPLICATES: check existing comments with 'gh pr view' before posting. LOGGING: in src-api/ code, console.* is forbidden — must use createLogger(). WORKSPACE: src-api/ must not use process.cwd() — use getSetting('workDir'). TYPES: import type must be used for type-only imports. I18N: new strings must exist in all 6 locale files (en, zh, es, fr, hi, pt). TAURI: flag overly broad capabilities or unvalidated IPC inputs. INLINE COMMENTS: only post inline comments if ENABLE_INLINE_COMMENTS is 'true', otherwise include all findings in the summary comment with file:line references."
+            --append-system-prompt "You are a senior engineer reviewing application (React 19 + Hono + Tauri 2 + Claude Agent SDK). Flag bugs, security issues, performance problems, and convention violations. Be direct and concise - no compliments, no filler. SINGLE AGENT: subagents and the Task tool are unavailable — never plan parallel passes, work sequentially. DIFF: read pr-files.txt then pr-diff.patch from disk; never run 'gh pr diff' (HTTP 406 on large PRs). COMPLETION: you MUST write review.md and post it via mcp__github_comment__update_claude_comment before your turn budget runs out, ending review.md (not the comment) with '<!-- claude-review-complete -->'; a partial review beats no review. DUPLICATES: check existing comments with 'gh pr view' before posting. LOGGING: in src-api/ code, console.* is forbidden — must use createLogger(). WORKSPACE: src-api/ must not use process.cwd() — use getSetting('workDir'). TYPES: import type must be used for type-only imports. I18N: new strings must exist in all 6 locale files (en, zh, es, fr, hi, pt). TAURI: flag overly broad capabilities or unvalidated IPC inputs. INLINE COMMENTS: only post inline comments if ENABLE_INLINE_COMMENTS is 'true', otherwise include all findings in the summary comment with file:line references."
 
       - name: Verify the review was posted
         if: ${{ !cancelled() && steps.diff.outcome == 'success' }}
@@ -571,36 +577,55 @@ jobs:
         run: |
           set -euo pipefail
 
-          # The source of truth is what is actually on the PR, not what is on disk. A local
-          # review.md proves only that Claude started writing — the run that prompted this
-          # workflow ended with a summary it never posted.
+          # Completion needs two independent facts, because neither alone is sufficient:
           #
-          # A comment counts as this run's if it did not exist before the run started, or if
-          # it carries the run id. Either signal alone is enough: the snapshot survives a
-          # change to how the action formats tracking comments, and the run id survives a
-          # missing snapshot. Requiring both would make the guard fail closed on every run
-          # if either mechanism drifted.
-          PRE_RUN_IDS=pre-run-claude-comments.txt
-          [ -f "$PRE_RUN_IDS" ] || : > "$PRE_RUN_IDS"
+          #   1. Claude finished writing  — review.md ends with the completion marker.
+          #   2. What it wrote reached the PR — this run's claude[bot] comment carries a
+          #      distinctive line from review.md.
+          #
+          # The marker cannot be checked on the comment: mcp__github_comment__update_claude_comment
+          # strips HTML comments from the body it posts. Run 34356058557 posted a complete review
+          # whose body was byte-identical to review.md except the marker was gone, and the guard
+          # failed a good review. (GitHub itself preserves HTML comments — CodeRabbit's comments
+          # on the same PR keep five. The sanitizing is the action's.) So the marker stays in the
+          # file, where it survives, and the comment is matched on visible content instead.
+          if ! [ -s review.md ] || ! grep -qF '<!-- claude-review-complete -->' review.md; then
+            REVIEW_POSTED=no
+          else
+            # Longest line of review.md, marker excluded: a content fingerprint that does not
+            # depend on any particular heading the prompt happens to ask for today.
+            # Every grep against it needs `--`: the longest line of a review is usually a
+            # markdown bullet, and a pattern starting with "-" is otherwise read as options.
+            FINGERPRINT=$(grep -vF '<!-- claude-review-complete -->' review.md \
+              | awk '{ print length, $0 }' | sort -rn | head -1 | cut -d' ' -f2-)
 
-          gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
-            --jq '.[] | select(.user.login == "claude[bot]") | "\(.id) \(.body | @base64)"' \
-            > claude-comments.txt || : > claude-comments.txt
+            PRE_RUN_IDS=pre-run-claude-comments.txt
+            [ -f "$PRE_RUN_IDS" ] || : > "$PRE_RUN_IDS"
 
-          REVIEW_POSTED=no
-          while read -r comment_id body_b64; do
-            [ -n "${body_b64:-}" ] || continue
-            body=$(printf '%s' "$body_b64" | base64 -d)
-            # Pre-existing and not stamped with this run id — belongs to an earlier review.
-            if grep -qx "$comment_id" "$PRE_RUN_IDS" \
-               && ! printf '%s' "$body" | grep -qF "$GITHUB_RUN_ID"; then
-              continue
-            fi
-            if printf '%s' "$body" | grep -qF '<!-- claude-review-complete -->'; then
-              REVIEW_POSTED=yes
-              break
-            fi
-          done < claude-comments.txt
+            gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --jq '.[] | select(.user.login == "claude[bot]") | "\(.id) \(.body | @base64)"' \
+              > claude-comments.txt || : > claude-comments.txt
+
+            # A comment counts as this run's if it did not exist before the run started, or if
+            # it carries the run id. Either signal alone is enough: the snapshot survives a
+            # change to how the action formats tracking comments, and the run id survives a
+            # missing snapshot. Requiring both would make the guard fail closed on every run
+            # if either mechanism drifted.
+            REVIEW_POSTED=no
+            while read -r comment_id body_b64; do
+              [ -n "${body_b64:-}" ] || continue
+              body=$(printf '%s' "$body_b64" | base64 -d)
+              # Pre-existing and not stamped with this run id — belongs to an earlier review.
+              if grep -qx -- "$comment_id" "$PRE_RUN_IDS" \
+                 && ! printf '%s' "$body" | grep -qF -- "$GITHUB_RUN_ID"; then
+                continue
+              fi
+              if [ -n "$FINGERPRINT" ] && printf '%s' "$body" | grep -qF -- "$FINGERPRINT"; then
+                REVIEW_POSTED=yes
+                break
+              fi
+            done < claude-comments.txt
+          fi
 
           if [ "$REVIEW_POSTED" = yes ]; then
             echo "Review posted and marked complete."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -109,6 +109,10 @@ env:
   REVIEW_EXCLUDE_PATHS: ${{ vars.REVIEW_EXCLUDE_PATHS || ':(exclude)dev-doc/** :(exclude)**/*.md :(exclude)pnpm-lock.yaml :(exclude)package-lock.json :(exclude)yarn.lock :(exclude)**/*.snap' }}
   # Turn budget for the review session. Without an explicit cap a large PR can exhaust the
   # default budget mid-analysis and end "successfully" without ever posting a summary.
+  # This is a runtime backstop only — it is deliberately NOT told to the model. Run 34356058557
+  # was asked to track its own budget and stopped at 39 of 80 turns, self-reporting "(budget)"
+  # as the reason it skipped files, because a model cannot observe its own turn count and so
+  # guesses conservatively. The prompt now tells it not to ration.
   REVIEW_MAX_TURNS: ${{ vars.REVIEW_MAX_TURNS || '80' }}
 
 permissions:
@@ -329,9 +333,11 @@ jobs:
 
             - **You are a single agent.** Subagents and the Task tool are NOT available. Do not
               plan "parallel passes" or announce a fan-out — every such attempt is denied and
-              burns your turn budget. Work sequentially through the prioritized file list.
-            - **Your turn budget is finite** (${{ env.REVIEW_MAX_TURNS }} turns). Track it. Reaching the end
-              of the diff is less important than posting a summary.
+              wastes a turn. Work sequentially through the prioritized file list.
+            - **Do not ration your own effort.** You cannot see how many turns you have used, so
+              any guess is wrong, and guessing low means stopping with the review half done. A
+              hard cap is enforced for you by the runtime — you do not need to manage it. Keep
+              reviewing until the prioritized list is genuinely covered.
             - **Only these commands are available**: `gh pr view`, `gh pr checks`, `cat CLAUDE.md`,
               `mkdir -p reports`. Anything else is denied — don't retry a denied command.
             - **Triage before reading.** If the diff is larger than you can fully cover, prioritize:
@@ -477,12 +483,17 @@ jobs:
             5. If GENERATE REPORT is "true", also create `reports/pr-${{ steps.pr.outputs.number }}-review.md`
                with code snippets showing violations and corrected examples as unified diffs.
 
-            ## Completion protocol (MANDATORY — do this even if you run out of budget)
+            ## Completion protocol (MANDATORY)
 
-            This is not optional and it is not the last thing you do "if there's time". The moment
-            you are more than three quarters through your turn budget, stop analyzing and do this:
+            Write `review.md` **early and keep it current** — draft it as soon as you have triaged
+            the file list, then append findings as you go. That way an unexpected stop still leaves
+            a usable review on disk, which is what makes it safe to keep reviewing rather than
+            stopping early to leave room. Do not save the writing for the end, and do not stop
+            analyzing in order to "reserve" turns.
 
-            1. Write the full summary to `review.md`, containing:
+            When the prioritized list is covered:
+
+            1. Finalize `review.md` so it contains:
                - Assessment: ✅ Approve / ⚠️ Request Changes / 💬 Comment
                - Issues: bulleted list grouped by severity (Critical → Warning → Info) with file:line references
                - **Layer Summary** (always include, even if every line says "No issues"):
@@ -564,7 +575,7 @@ jobs:
             --max-turns ${{ env.REVIEW_MAX_TURNS }}
             ${{ env.ENABLE_EXTENDED_THINKING == 'true' && '--thinking=enabled' || '' }}
             --allowedTools Read,Glob,Grep,mcp__github_comment__update_claude_comment,Bash(gh pr view:*),Bash(gh pr checks:*),Bash(cat CLAUDE.md),Write(review.md),Edit(review.md),Write(reports/*),Bash(mkdir -p reports)${{ env.ENABLE_INLINE_COMMENTS == 'true' && ',mcp__github_inline_comment__create_inline_comment' || '' }}
-            --append-system-prompt "You are a senior engineer reviewing application (React 19 + Hono + Tauri 2 + Claude Agent SDK). Flag bugs, security issues, performance problems, and convention violations. Be direct and concise - no compliments, no filler. SINGLE AGENT: subagents and the Task tool are unavailable — never plan parallel passes, work sequentially. DIFF: read pr-files.txt then pr-diff.patch from disk; never run 'gh pr diff' (HTTP 406 on large PRs). COMPLETION: you MUST write review.md and post it via mcp__github_comment__update_claude_comment before your turn budget runs out, ending review.md (not the comment) with '<!-- claude-review-complete -->'; a partial review beats no review. DUPLICATES: check existing comments with 'gh pr view' before posting. LOGGING: in src-api/ code, console.* is forbidden — must use createLogger(). WORKSPACE: src-api/ must not use process.cwd() — use getSetting('workDir'). TYPES: import type must be used for type-only imports. I18N: new strings must exist in all 6 locale files (en, zh, es, fr, hi, pt). TAURI: flag overly broad capabilities or unvalidated IPC inputs. INLINE COMMENTS: only post inline comments if ENABLE_INLINE_COMMENTS is 'true', otherwise include all findings in the summary comment with file:line references."
+            --append-system-prompt "You are a senior engineer reviewing application (React 19 + Hono + Tauri 2 + Claude Agent SDK). Flag bugs, security issues, performance problems, and convention violations. Be direct and concise - no compliments, no filler. SINGLE AGENT: subagents and the Task tool are unavailable — never plan parallel passes, work sequentially. DIFF: read pr-files.txt then pr-diff.patch from disk; never run 'gh pr diff' (HTTP 406 on large PRs). COMPLETION: draft review.md early and keep it current as you go, then post it via mcp__github_comment__update_claude_comment, ending review.md (not the comment) with '<!-- claude-review-complete -->'. Do not ration turns or stop early to reserve room — you cannot observe your turn count and the runtime enforces the cap for you; review the prioritized list fully. A partial review beats no review. DUPLICATES: check existing comments with 'gh pr view' before posting. LOGGING: in src-api/ code, console.* is forbidden — must use createLogger(). WORKSPACE: src-api/ must not use process.cwd() — use getSetting('workDir'). TYPES: import type must be used for type-only imports. I18N: new strings must exist in all 6 locale files (en, zh, es, fr, hi, pt). TAURI: flag overly broad capabilities or unvalidated IPC inputs. INLINE COMMENTS: only post inline comments if ENABLE_INLINE_COMMENTS is 'true', otherwise include all findings in the summary comment with file:line references."
 
       - name: Verify the review was posted
         if: ${{ !cancelled() && steps.diff.outcome == 'success' }}


### PR DESCRIPTION
First live run of the reviewer on #29 ([34356058557](https://github.com/bravew/Neumar/actions/runs/34356058557)). **The #31 fixes worked. The guard I added on top of them did not.**

## What worked

| | Run 34312666877 (before) | Run 34356058557 (after) |
|---|---|---|
| Diff obtained | ❌ HTTP 406, nothing | ✅ 117 files, 15,710 lines |
| Turns / denials | 16 turns, **14 denials** | 39 turns, **3 denials** |
| Review posted | ❌ unchecked checklist | ✅ full review |
| Cost | $2.11 | $1.72 |

Claude posted a real review — severity-grouped findings, complete Layer Summary, explicit coverage/not-covered notes. It flagged that the nine multicam MCP tools appear unwired (imported only from tests, never registered in `video-edit-server.ts`), which is worth a look on #29 independently of this PR.

Stale comment collapsing worked too, and the marker-scoped filter did its job: the three orphaned `claude[bot]` comments are minimized, while CodeRabbit's comment and all human comments stayed expanded.

## What broke

The guard failed the job anyway, and posted a duplicate salvage comment.

It checked for `<!-- claude-review-complete -->` in the **posted comment**. `mcp__github_comment__update_claude_comment` strips HTML comments. Diffing the artifact against the live comment, the only difference is the marker:

```
$ diff review.md posted-body.md
35,36d33
< <!-- claude-review-complete -->
```

GitHub is not the culprit — CodeRabbit's comments on the same PR carry **five** intact HTML comments. The sanitizing is the action's. No prompt wording fixes this; the marker cannot survive that tool.

I flagged this exact false-positive risk when designing the guard and accepted it. That was the wrong call, and it fired on the first real run.

## The fix

Completion is now two facts, each observed where it actually survives:

1. **`review.md` ends with the marker** — Claude finished writing. Files aren't sanitized.
2. **This run's `claude[bot]` comment contains `review.md`'s longest line** — what it wrote reached the PR. Visible text, so nothing strips it.

Neither alone is sufficient: 34312666877 wrote no `review.md` *and* posted only a checklist.

The fingerprint is content-based rather than keyed to a heading like "Layer Summary", so rewording the prompt can't silently break it.

## A bug the test caught

Replaying real data through the new logic failed with `grep: invalid option`. The longest line of a review is almost always a markdown bullet, and `grep -qF "$FINGERPRINT"` reads a leading `-` as options. Every grep against the fingerprint now passes `--`. This would have broken in production.

## Verification

Replayed against both runs' real comment bodies and downloaded artifacts:

| Scenario | Result |
|---|---|
| 34356058557 — good review, marker stripped from comment | **passes** ✅ (previously failed) |
| 34312666877 — no `review.md`, stalled checklist | fails ✅ |
| `review.md` complete but nothing posted this run | fails ✅ |
| `review.md` unfinished (no marker) | fails ✅ |

actionlint clean.

## Still open, not addressed here

`REVIEW_MAX_TURNS` is 80 but the session used 39 and stopped — the review is thorough yet explicitly partial (`multicam/sync.ts`, `shot-plan.ts`, several editor-handoff files not covered). The turn budget wasn't the binding constraint, so something else ended it. Worth investigating separately rather than bundling in.

https://claude.ai/code/session_01MKeQK5rfizpX6EhzysELCR