### PR TITLE
fix(video): end handle drags on cancel and unmount, and answer rejected review actions

### DIFF
--- a/src-api/src/shared/mcp/video-multicam-tools.ts
+++ b/src-api/src/shared/mcp/video-multicam-tools.ts
@@ -5,6 +5,7 @@ import { alreadyApplied, buildApplyBatch } from '@/shared/video/multicam/apply';
 import { manifestReadiness } from '@/shared/video/multicam/manifest';
 import {
   applyReviewAction,
+  ReviewActionError,
   startReview,
   summarizeReview,
   type ReviewAction,
@@ -47,7 +48,11 @@ export type MulticamToolName = (typeof MULTICAM_TOOL_NAMES)[number];
 
 export interface MulticamUnavailable {
   available: false;
-  reason: 'feature-disabled' | 'no-camera-group' | 'no-analysis';
+  reason:
+    | 'feature-disabled'
+    | 'no-camera-group'
+    | 'no-analysis'
+    | 'invalid-action';
   detail: string;
 }
 
@@ -214,7 +219,20 @@ async function mutateReview(
   }
   const existing = await loadReview(projectId, groupId);
   const review = existing?.data ?? startReview(plan.data);
-  const next = applyReviewAction(review, action);
+  // `applyReviewAction` rejects an unknown shot, a nudge that would collapse a
+  // shot, and any action on an already-applied review. The HTTP route turns that
+  // into a 409; here it would escape as an unhandled exception, which the agent
+  // sees as a tool crash rather than a result it can act on. Every other failure
+  // in this file answers with the same structured shape, so this one does too.
+  let next;
+  try {
+    next = applyReviewAction(review, action);
+  } catch (error) {
+    if (error instanceof ReviewActionError) {
+      return unavailable('invalid-action', error.message);
+    }
+    throw error;
+  }
   await saveReview(projectId, next);
   return { available: true as const, review: summarizeReview(next) };
 }

--- a/src/components/video/timeline/TimelineOutputRangeOverlay.tsx
+++ b/src/components/video/timeline/TimelineOutputRangeOverlay.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+
 import { cn } from '@/shared/lib/utils';
 import type { VideoTimelineOutputRange } from '@/shared/types/video';
 
@@ -104,6 +106,13 @@ function RangeHandle({
   pixelsPerSecond: number;
   onMove: (ms: number) => void;
 }) {
+  // A drag registers window listeners that only `pointerup` used to remove, so a
+  // cancelled gesture (touch interrupted, browser take-over) or an unmount mid-drag
+  // left them attached, still calling `onMove` on every subsequent pointer move.
+  // The controller ends the drag exactly once from any of those paths.
+  const dragRef = useRef<AbortController | null>(null);
+  useEffect(() => () => dragRef.current?.abort(), []);
+
   return (
     <button
       type="button"
@@ -127,16 +136,21 @@ function RangeHandle({
         const ruler = event.currentTarget.parentElement;
         if (!ruler) return;
         const rect = ruler.getBoundingClientRect();
+        dragRef.current?.abort();
+        const drag = new AbortController();
+        dragRef.current = drag;
+        const { signal } = drag;
         const move = (pointer: PointerEvent) => {
           const x = pointer.clientX - rect.left - headerWidth;
           onMove(Math.max(0, (x / pixelsPerSecond) * 1000));
         };
-        const up = () => {
-          window.removeEventListener('pointermove', move);
-          window.removeEventListener('pointerup', up);
+        const end = () => {
+          drag.abort();
+          if (dragRef.current === drag) dragRef.current = null;
         };
-        window.addEventListener('pointermove', move);
-        window.addEventListener('pointerup', up);
+        window.addEventListener('pointermove', move, { signal });
+        window.addEventListener('pointerup', end, { signal });
+        window.addEventListener('pointercancel', end, { signal });
       }}
     />
   );


### PR DESCRIPTION
Acting on the automated review of #29 ([comment](https://github.com/bravew/Neumar/pull/29#issuecomment-5602485828)). Targets `feat/video-reference-upgrades` so it lands inside #29 rather than around it.

I checked all five findings against the code. **Two were valid and mechanical — fixed here. Three I deliberately did not touch**, reasons below.

## Fixed

**Handle drags leaked listeners** — `TimelineOutputRangeOverlay.tsx`

`onPointerDown` registered `pointermove`/`pointerup` on `window` and removed them only from `pointerup`. A cancelled gesture (touch interrupted, browser take-over) or an unmount mid-drag — switching projects while dragging — left both attached, and the closure kept calling `onMove` on every later pointer move. An `AbortController` now ends the drag from any path, including `pointercancel` and an unmount effect. Matches the effect-cleanup convention in CLAUDE.md.

**Rejected review actions escaped as exceptions** — `video-multicam-tools.ts`

`mutateReview()` called `applyReviewAction()` without catching `ReviewActionError`, which it throws for an unknown shot, a nudge that would collapse a shot, and any action on an already-applied review. `video.ts:2473` turns that into a 409; on the tool path it escaped, so an agent would see a crash instead of a result it could act on. It now returns the same structured shape every other failure in that file uses, via a new `'invalid-action'` reason. I checked that no consumer switches exhaustively on that union, so widening it is safe.

## Not fixed, on purpose

**The nine multicam tools are genuinely unwired** — confirmed, and the most significant finding, but not mine to guess at.

- `video-multicam-tools.ts` is imported only from two test files
- `video-edit-server.ts` contains **zero** occurrences of `multicam`
- `shouldRegisterMulticamTools` is called only from its own test

The phase-6 evidence claims "Nine tools, all classified" and that the domain is withheld without a camera group — both true — but never claims registration. `video-edit-server.test.ts:130` looks like it proves registration; it asserts over the *classification* map, and its own comment says the domain "is classified without appearing in the always-on list", so it passes eitherway.

Wiring needs nine `tool()` wrappers **and a design decision**: `shouldRegisterMulticamTools` is `async` and per-project, while `createVideoEditServer` is synchronous. That's your architecture call, and guessing it would be worse than saying so.

**Lock re-entrancy** (`project-lock.ts`) — real as described: two `withProjectLock` calls for the same project inside an outer lock both run inline. But the inline path is deliberate and documented (re-queueing would deadlock on your own stack), and nothing exercises the pattern. Adding a guard could break legitimate nesting; a trade-off you already reasoned about is not a bug.

**`multicamSetPolicy` doesn't persist** — the review itself concedes this matches the phase-6 scope note. No change.

## Separately: typecheck is red, and it isn't this PR

While verifying, `pnpm typecheck:api` fails:

```
src/shared/video/pipeline.ts(2240,54): error TS2345: 'MediaItem | undefined' not assignable to 'MediaItem'
src/shared/video/pipeline.ts(2276,38): error TS2345: 'MediaItem | undefined' not assignable to 'Pick<MediaItem, "path" | "origin">'
```

**These are on `main` too** (same errors at 2228/2264 — the offset is just this PR's additions), so #29 neither caused nor fixed them. Cause: `assetCanProvideAudio()` returns plain `boolean` rather than a type predicate, so TS can't narrow `asset` after the guard. Runtime is fine — the guard rejects `undefined` — but `pnpm validate` cannot pass. `remotion-render-input.ts:396` already carries an `|| !asset` workaround for exactly this.

A one-line fix (make it `asset is T`) unblocks it repo-wide. Left out of this PR because it belongs against `main`, not inside #29 — say the word and I'll send it.

## Verification

- 569 frontend tests across 113 files, 15 multicam tool tests — all pass
- oxlint clean on both changed files
- `typecheck:api` reports the same two pre-existing errors and no new ones

https://claude.ai/code/session_01MKeQK5rfizpX6EhzysELCR