### PR TITLE
fix(video): narrow audio assets before use so typecheck:api passes

### DIFF
--- a/src-api/src/shared/video/pipeline.ts
+++ b/src-api/src/shared/video/pipeline.ts
@@ -2224,7 +2224,7 @@ function collectProjectAudioTracks(
     for (const clip of track.clips) {
       if (clip.muted) continue;
       const asset = assetForSourceRef(project, clip.sourceRef);
-      if (!assetCanProvideAudio(asset)) continue;
+      if (!asset || !assetCanProvideAudio(asset)) continue;
       tracks.push(audioTrackClipFromEdl(track, clip, asset, root));
     }
   }
@@ -2256,7 +2256,7 @@ export function collectSoundtrackAudioTracks(
   const resolveAudioPath = (assetId?: string): string | undefined => {
     if (!assetId) return undefined;
     const asset = project.assets.find((item) => item.id === assetId);
-    if (!assetCanProvideAudio(asset)) return undefined;
+    if (!asset || !assetCanProvideAudio(asset)) return undefined;
     // Skip non-fatally when the backing file is gone (purged upload, path
     // mismatch) or fails path validation — a missing soundtrack asset must not
     // abort the whole render. validateInputFile throws in both cases.

--- a/src-api/src/shared/video/remotion-render-input.ts
+++ b/src-api/src/shared/video/remotion-render-input.ts
@@ -393,7 +393,7 @@ function audioClipFromEdl(
   fps: number,
 ): RemotionRenderAudioClip[] {
   const asset = assetForSourceRef(project, clip.sourceRef);
-  if (!assetCanProvideAudio(asset) || !asset) return [];
+  if (!asset || !assetCanProvideAudio(asset)) return [];
 
   const sourcePath = resolveProjectAssetPath(asset, root);
   const sourceStartFrame = msToFrame(clip.sourceStartMs, fps);


### PR DESCRIPTION
`pnpm typecheck:api` is currently red on `main`, so `pnpm validate` cannot pass:

```
src/shared/video/pipeline.ts(2228,54): error TS2345: 'MediaItem | undefined' is not assignable to 'MediaItem'
src/shared/video/pipeline.ts(2264,38): error TS2345: 'MediaItem | undefined' is not assignable to 'Pick<MediaItem, "path" | "origin">'
```

Found while verifying #34. It predates #29 — the same two errors are on `main`, at shifted line numbers.

## Cause

`assetCanProvideAudio()` takes `MediaItem | undefined` and returns a plain `boolean`. It rejects `undefined` at runtime but tells the type system nothing, so both call sites passed a still-optional value onward.

## Why not a type predicate

The obvious fix is `asset is MediaItem`. That would be a lie: the function also returns false for a *defined* asset that happens to be an image, so a predicate would tell the compiler the false branch is `undefined` when it may hold a real asset. No caller reads `asset` there today, but the narrowing would be wrong the day one does — and it would fail silently, as a wrong type rather than an error.

Checking `!asset` first narrows honestly, changes no shared contract, and is what `remotion-render-input.ts:396` was already reaching for with `|| !asset` — in the wrong order to narrow anything:

```diff
-  if (!assetCanProvideAudio(asset) || !asset) return [];
+  if (!asset || !assetCanProvideAudio(asset)) return [];
```

All three call sites now read the same way. This is pure reordering of a short-circuit whose first operand already returned false for `undefined`, so runtime behavior is identical in all three cases.

## Verification

- `pnpm typecheck:api` — **clean** (was 2 errors)
- `test/unit/video` — 805 passing
- oxlint clean on both files

**Pre-existing, not addressed here:** `remotion-render-input.test.ts` has 2 failing tests. I confirmed they fail identically on unmodified `main`, so they are neither caused nor fixed by this change. Worth a separate look — happy to dig in if you want.

https://claude.ai/code/session_01MKeQK5rfizpX6EhzysELCR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing audio assets during video processing.
  * Prevented errors when audio clips or soundtrack references point to unavailable assets.
  * Ensured audio capability checks are only performed when an asset is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->