### PR TITLE
ci: stop the reviewer citing patch offsets as source lines

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -329,6 +329,25 @@ jobs:
             tool's offset/limit parameters, working through the files you prioritized from
             `pr-files.txt`. Use Read/Glob/Grep on the checked-out tree for surrounding context.
 
+            ### Line numbers: a position in the patch is NOT a source line
+
+            `pr-diff.patch` concatenates every file, so a finding on line 14342 of the patch may sit
+            at line 128 of a 143-line source file. Citing the patch offset sends the reader to a
+            line that does not exist. Earlier runs of this workflow did exactly that.
+
+            To cite a real line, use the enclosing hunk header:
+
+            ```
+            @@ -12,7 +12,9 @@       <- +12 is the first new-file line in this hunk
+            ```
+
+            Count added (`+`) and context (` `) lines from that start, ignoring removed (`-`) lines.
+            When a hunk is long or you are unsure, `Read` the file from the checked-out tree and
+            confirm the number there — the working tree is the PR's own code.
+
+            If you still cannot pin a line, cite the symbol instead (`applyReviewAction()` in
+            `review.ts`). A correct file-and-symbol beats a confident wrong number.
+
             ## Working constraints (violating these is how reviews end up empty)
 
             - **You are a single agent.** Subagents and the Task tool are NOT available. Do not
@@ -563,7 +582,8 @@ jobs:
             - Be direct and concise - state issue, location, fix. No filler text.
             - Skip formatting nitpicks (oxlint and oxfmt handle formatting)
             - Flag real issues only: bugs, security risks, performance problems, convention violations
-            - Cite file paths and line numbers when referencing code
+            - Cite file paths and line numbers when referencing code — real source lines,
+              never positions in `pr-diff.patch` (see the line-numbers note above)
             - Do NOT modify source code files
             - Use collapsible sections for technical depth
             - **NEVER use `gh pr comment` or `gh pr diff`** — the summary goes through
@@ -575,7 +595,7 @@ jobs:
             --max-turns ${{ env.REVIEW_MAX_TURNS }}
             ${{ env.ENABLE_EXTENDED_THINKING == 'true' && '--thinking=enabled' || '' }}
             --allowedTools Read,Glob,Grep,mcp__github_comment__update_claude_comment,Bash(gh pr view:*),Bash(gh pr checks:*),Bash(cat CLAUDE.md),Write(review.md),Edit(review.md),Write(reports/*),Bash(mkdir -p reports)${{ env.ENABLE_INLINE_COMMENTS == 'true' && ',mcp__github_inline_comment__create_inline_comment' || '' }}
-            --append-system-prompt "You are a senior engineer reviewing application (React 19 + Hono + Tauri 2 + Claude Agent SDK). Flag bugs, security issues, performance problems, and convention violations. Be direct and concise - no compliments, no filler. SINGLE AGENT: subagents and the Task tool are unavailable — never plan parallel passes, work sequentially. DIFF: read pr-files.txt then pr-diff.patch from disk; never run 'gh pr diff' (HTTP 406 on large PRs). COMPLETION: draft review.md early and keep it current as you go, then post it via mcp__github_comment__update_claude_comment, ending review.md (not the comment) with '<!-- claude-review-complete -->'. Do not ration turns or stop early to reserve room — you cannot observe your turn count and the runtime enforces the cap for you; review the prioritized list fully. A partial review beats no review. DUPLICATES: check existing comments with 'gh pr view' before posting. LOGGING: in src-api/ code, console.* is forbidden — must use createLogger(). WORKSPACE: src-api/ must not use process.cwd() — use getSetting('workDir'). TYPES: import type must be used for type-only imports. I18N: new strings must exist in all 6 locale files (en, zh, es, fr, hi, pt). TAURI: flag overly broad capabilities or unvalidated IPC inputs. INLINE COMMENTS: only post inline comments if ENABLE_INLINE_COMMENTS is 'true', otherwise include all findings in the summary comment with file:line references."
+            --append-system-prompt "You are a senior engineer reviewing application (React 19 + Hono + Tauri 2 + Claude Agent SDK). Flag bugs, security issues, performance problems, and convention violations. Be direct and concise - no compliments, no filler. SINGLE AGENT: subagents and the Task tool are unavailable — never plan parallel passes, work sequentially. DIFF: read pr-files.txt then pr-diff.patch from disk; never run 'gh pr diff' (HTTP 406 on large PRs). LINE NUMBERS: a position in pr-diff.patch is not a source line — derive real lines from the enclosing '@@ -old,+new @@' hunk header or by reading the file, and cite the symbol name when unsure. COMPLETION: draft review.md early and keep it current as you go, then post it via mcp__github_comment__update_claude_comment, ending review.md (not the comment) with '<!-- claude-review-complete -->'. Do not ration turns or stop early to reserve room — you cannot observe your turn count and the runtime enforces the cap for you; review the prioritized list fully. A partial review beats no review. DUPLICATES: check existing comments with 'gh pr view' before posting. LOGGING: in src-api/ code, console.* is forbidden — must use createLogger(). WORKSPACE: src-api/ must not use process.cwd() — use getSetting('workDir'). TYPES: import type must be used for type-only imports. I18N: new strings must exist in all 6 locale files (en, zh, es, fr, hi, pt). TAURI: flag overly broad capabilities or unvalidated IPC inputs. INLINE COMMENTS: only post inline comments if ENABLE_INLINE_COMMENTS is 'true', otherwise include all findings in the summary comment with file:line references."
 
       - name: Verify the review was posted
         if: ${{ !cancelled() && steps.diff.outcome == 'success' }}


### PR DESCRIPTION
Every review this workflow has produced carries line numbers that point nowhere.

| Cited | Actual file length |
|---|---|
| `TimelineOutputRangeOverlay.tsx:14342-14359` | 143 lines |
| `project-lock.ts:7422-7429` | 58 lines |
| `review.ts:5816-5825` | 233 lines |
| `TimelineOutputRangeOverlay.tsx:342-359` (latest run) | 143 lines |

## Cause

Mine, from the diff handoff in #31. `pr-diff.patch` concatenates every file, so a finding at patch line 14342 sits at line 128 of its own source file. I verified this directly — patch line 14342 falls inside the `TimelineOutputRangeOverlay.tsx` hunk whose header is at 14214. The prompt asked for "file paths and line numbers" without ever saying *which* numbering.

The findings themselves were sound — I acted on two of them in #34. The coordinates were not, and a wrong line is worse than no line, because it sends the reader somewhere that looks real.

## Fix

The patch already carries what's needed:

```
@@ -0,0 +1,143 @@      <- +1 is the first new-file line in this hunk
```

The prompt now states that a patch position is not a source line, shows how to derive the real one from the enclosing hunk header, and says to confirm against the checked-out file when a hunk is long. When a line still can't be pinned, cite the symbol instead — `applyReviewAction()` in `review.ts` is more useful than a confident wrong number.

Stated in all three places the model actually reads: the diff-reading section, the rules list, and the `--append-system-prompt` one-liner.

## Verification

actionlint clean. Beyond that this is a prompt change, so the honest test is the next `@review` — check whether cited lines land on the code they describe.

https://claude.ai/code/session_01MKeQK5rfizpX6EhzysELCR