### PR TITLE
ci: verify the posted review structurally instead of by matching bytes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -62,6 +62,17 @@ name: Claude - Diff-Aware PR Reviewer
 #   half-finished review can never masquerade as a green check.
 # - Guard notices carry <!-- claude-review-guard --> so the next run collapses them.
 #
+# EXPECTED LOG NOISE
+# - The run log carries a burst of "fatal: could not open <path> ... No such file or directory",
+#   often hundreds of lines. They are not from this workflow and not a failure. The action's own
+#   fetchGitHubData (src/github/data/fetcher.ts, during prepareTagMode, before Claude starts) runs
+#   `git hash-object` over every changed file. On an issue_comment event actions/checkout gives
+#   main's tree, so files the PR *adds* are not on disk and cannot be hashed. The action catches
+#   each one, logs "warn: Failed to compute SHA", and continues. "fatal:" is git's prefix for every
+#   error, not a job status.
+# - Those SHAs only feed inline-comment anchoring. Silencing them would mean checking out the PR
+#   head, which this workflow deliberately does not do — see SECURITY below.
+#
 # SECURITY
 # - This workflow does not modify source code. It only posts comments and writes reports.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -107,6 +107,10 @@ env:
   # Space-separated git pathspecs excluded from the reviewed diff. Prose and generated
   # lockfiles crowd out code without carrying review-worthy findings.
   REVIEW_EXCLUDE_PATHS: ${{ vars.REVIEW_EXCLUDE_PATHS || ':(exclude)dev-doc/** :(exclude)**/*.md :(exclude)pnpm-lock.yaml :(exclude)package-lock.json :(exclude)yarn.lock :(exclude)**/*.snap' }}
+  # The heading that marks a posted comment as a finished review rather than a progress
+  # checklist. The prompt mandates it and the completion guard looks for it, so it is defined
+  # once here — if it drifts in one place the review silently stops being verifiable.
+  REVIEW_REQUIRED_SECTION: ${{ vars.REVIEW_REQUIRED_SECTION || 'Layer Summary' }}
   # Turn budget for the review session. Without an explicit cap a large PR can exhaust the
   # default budget mid-analysis and end "successfully" without ever posting a summary.
   # This is a runtime backstop only — it is deliberately NOT told to the model. Run 34356058557
@@ -515,7 +519,7 @@ jobs:
             1. Finalize `review.md` so it contains:
                - Assessment: ✅ Approve / ⚠️ Request Changes / 💬 Comment
                - Issues: bulleted list grouped by severity (Critical → Warning → Info) with file:line references
-               - **Layer Summary** (always include, even if every line says "No issues"):
+               - **${{ env.REVIEW_REQUIRED_SECTION }}** (always include verbatim, even if every line says "No issues"):
                  - 🖥️ Frontend: React/TypeScript issues found (or "No issues")
                  - ⚙️ Backend: Hono/Agent/Streaming issues found (or "No issues")
                  - 🔒 Security: Tauri capabilities, credential exposure, injection risks (or "No issues")
@@ -588,7 +592,9 @@ jobs:
             - Use collapsible sections for technical depth
             - **NEVER use `gh pr comment` or `gh pr diff`** — the summary goes through
               `mcp__github_comment__update_claude_comment`, and the diff is already on disk
-            - **ALWAYS include a Layer Summary section** in the PR summary comment — even if only to say "No issues"
+            - **ALWAYS include a `${{ env.REVIEW_REQUIRED_SECTION }}` section, spelled exactly that way**, in the
+              posted comment — even if only to say "No issues". It is how the workflow tells a
+              finished review from an abandoned progress checklist.
 
           claude_args: |
             --model ${{ env.CLAUDE_MODEL }}
@@ -605,31 +611,34 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           CLAUDE_CONCLUSION: ${{ steps.claude.outputs.conclusion }}
+          REQUIRED_SECTION: ${{ env.REVIEW_REQUIRED_SECTION }}
         run: |
           set -euo pipefail
 
           # Completion needs two independent facts, because neither alone is sufficient:
           #
           #   1. Claude finished writing  — review.md ends with the completion marker.
-          #   2. What it wrote reached the PR — this run's claude[bot] comment carries a
-          #      distinctive line from review.md.
+          #   2. A finished review reached the PR — this run's claude[bot] comment carries the
+          #      required section heading.
           #
-          # The marker cannot be checked on the comment: mcp__github_comment__update_claude_comment
-          # strips HTML comments from the body it posts. Run 34356058557 posted a complete review
-          # whose body was byte-identical to review.md except the marker was gone, and the guard
-          # failed a good review. (GitHub itself preserves HTML comments — CodeRabbit's comments
-          # on the same PR keep five. The sanitizing is the action's.) So the marker stays in the
-          # file, where it survives, and the comment is matched on visible content instead.
+          # Neither fact is checked on the other's artifact, because each is only observable
+          # where it survives:
+          #
+          # The marker is checked on the FILE, never the comment.
+          # mcp__github_comment__update_claude_comment strips HTML comments from the body it
+          # posts. Run 34356058557 posted a complete review, byte-identical to review.md except
+          # the stripped marker, and the guard failed it. (GitHub preserves HTML comments —
+          # CodeRabbit's on the same PR keep five. The sanitizing is the action's.)
+          #
+          # The comment is checked STRUCTURALLY, never by matching review.md's text. Claude
+          # legitimately polishes while posting — run 34360047300 reworded as it went and added
+          # a verification block, leaving only 5 of 18 substantive lines byte-identical, and a
+          # fingerprint-matching guard failed that good review too. The posted comment was the
+          # better of the two. What reliably separates a finished review from an abandoned
+          # progress checklist is the mandated section heading, so that is what is checked.
           if ! [ -s review.md ] || ! grep -qF '<!-- claude-review-complete -->' review.md; then
             REVIEW_POSTED=no
           else
-            # Longest line of review.md, marker excluded: a content fingerprint that does not
-            # depend on any particular heading the prompt happens to ask for today.
-            # Every grep against it needs `--`: the longest line of a review is usually a
-            # markdown bullet, and a pattern starting with "-" is otherwise read as options.
-            FINGERPRINT=$(grep -vF '<!-- claude-review-complete -->' review.md \
-              | awk '{ print length, $0 }' | sort -rn | head -1 | cut -d' ' -f2-)
-
             PRE_RUN_IDS=pre-run-claude-comments.txt
             [ -f "$PRE_RUN_IDS" ] || : > "$PRE_RUN_IDS"
 
@@ -651,7 +660,16 @@ jobs:
                  && ! printf '%s' "$body" | grep -qF -- "$GITHUB_RUN_ID"; then
                 continue
               fi
-              if [ -n "$FINGERPRINT" ] && printf '%s' "$body" | grep -qF -- "$FINGERPRINT"; then
+              # An abandoned run leaves the tracking comment as a progress checklist, which
+              # could still name the required section in a "- [ ] Write Layer Summary" item.
+              # An unchecked box is the thing that actually distinguishes it: run 34312666877's
+              # stalled comment has seven, and every real review posted so far has none.
+              if printf '%s' "$body" | grep -qF -- '- [ ]'; then
+                continue
+              fi
+              # `--` because a heading could begin with a dash; `-i` because markdown
+              # heading case is not worth failing a good review over.
+              if printf '%s' "$body" | grep -qiF -- "$REQUIRED_SECTION"; then
                 REVIEW_POSTED=yes
                 break
               fi


### PR DESCRIPTION
Third run of the reviewer, third good review my guard rejected. [Run 34360047300](https://github.com/bravew/Neumar/actions/runs/34360047300) wrote `review.md` with the completion marker, posted a complete review, and the job still went red.

## What went wrong

The guard required the posted comment to contain `review.md`'s longest line. Claude **reformats while posting** — it retitled `#` → `###`, folded the assessment heading in, added a `<details>Verification</details>` block with grep output, and rewrote several bullets.

Measured against the real artifacts: **only 5 of 18** substantive lines survived byte-identical.

The posted version was the *better* of the two — it also dropped a `:4168` citation that `review.md` had gotten wrong. Run 34356058557 passed this check only because it happened to post verbatim. That was luck, not verification.

## Byte-identity was never the right property

What separates a finished review from an abandoned progress checklist is structure. The guard now checks two things on the posted comment:

- it contains the mandated section heading
- it carries **no** unchecked `- [ ]` box

The second closes the obvious hole in the first: a checklist could name the section in a `- [ ] Write Layer Summary` item. Measured on real comments:

| Comment | Unchecked boxes |
|---|---|
| Run 34312666877 stalled checklist | **7** |
| Run 34356058557 review | 0 |
| Run 34360047300 review | 0 |

## One source of truth

The heading is now `REVIEW_REQUIRED_SECTION`, interpolated into both prompt mandates **and** the guard. Previously the prompt asked for "Layer Summary" in prose while nothing depended on it — if that wording drifted, the review would silently stop being verifiable. Now the drift would be in one place.

## Verification

Replayed against all three runs' real comment bodies and downloaded artifacts:

| Scenario | Result |
|---|---|
| 34360047300 — reworded post (**this version exists for it**) | passes ✅ |
| 34356058557 — byte-identical post, marker stripped | passes ✅ |
| 34312666877 — no `review.md`, stalled checklist | fails ✅ |
| complete `review.md` that never reached the PR | fails ✅ |
| unfinished `review.md` (no marker) | fails ✅ |

actionlint clean.

## Not addressed: the 232 `fatal:` lines in the log

Cosmetic, and not from this workflow. They come from the action's own `fetchGitHubData` (`fetcher.ts:495`, during `prepareTagMode`, before Claude starts), which runs `git hash-object` on every changed file. On an `issue_comment` event the checkout is main's tree, so files the PR *adds* aren't on disk. The action catches each one, logs `warn: Failed to compute SHA`, and continues; those SHAs feed inline-comment anchoring, which is off here. `fatal:` is git's prefix for every error, not a job failure.

Not worth chasing — the obvious fix is checking out the PR head, which this workflow deliberately avoids for untrusted code.

https://claude.ai/code/session_01MKeQK5rfizpX6EhzysELCR