### PR TITLE
ci: make demo video rendering manual

### DIFF
--- a/.github/workflows/render-videos.yml
+++ b/.github/workflows/render-videos.yml
@@ -1,6 +1,8 @@
 name: Render Demo Videos
 
 on:
+  # Rendering currently depends on local demo assets that are not available in
+  # CI. Keep this manual until the render bundle is self-contained.
   workflow_dispatch:
     inputs:
       composition:
@@ -15,12 +17,6 @@ on:
           - preview
           - draft
           - final
-  push:
-    paths:
-      - 'src-video/**'
-    branches:
-      - main
-
 permissions:
   contents: read
 


### PR DESCRIPTION
## Why

The Render Demo Videos workflow currently depends on local screenshot assets that are unavailable in CI. The merge of PR #29 triggered it automatically, and the job failed while loading `public/screenshots/home-with-tasks.png`.

## Change

Remove the `push` trigger for `src-video/**`. Keep `workflow_dispatch` so the workflow can still be run deliberately after its assets are fixed.

## Verification

- `actionlint -shellcheck= -pyflakes= .github/workflows/render-videos.yml`
- `git diff --check`

This change does not run the video renderer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Video rendering workflows are now triggered manually rather than automatically when video source files change on the main branch.
  * Added documentation explaining the manual rendering process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->