### PR TITLE
chore: release v26.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+## [26.9.9] - 2026-09-09
+
+### Added
+
+- **video**: expand Video Mode with durable planning and external-footage export.
+- **mcp**: accept inbound MCP connections from Codex and Claude Code.
+
+### Fixed
+
+- **video**: validate audio assets before use to keep video workflows reliable.
+
 ## [26.8.27] - 2026-08-27
 
 Maintenance release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neumar",
-  "version": "26.8.27",
+  "version": "26.9.9",
   "private": true,
   "homepage": "https://github.com/bravew/Neumar#readme",
   "bugs": {

--- a/src-api/package.json
+++ b/src-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neumar-api",
-  "version": "26.8.27",
+  "version": "26.9.9",
   "type": "module",
   "scripts": {
     "predev": "pnpm --filter @neumar/video-ir build",

--- a/src-api/test/integration/api/agent.test.ts
+++ b/src-api/test/integration/api/agent.test.ts
@@ -46,6 +46,11 @@ vi.mock('@/shared/plugins', () => ({
   ),
 }));
 
+vi.mock('@/shared/services/external-mcp/run-commands', () => ({
+  registerExternalMcpRunLauncher: vi.fn(),
+  registerExternalMcpRunSession: vi.fn(),
+}));
+
 vi.mock('@/shared/services/task-event-bus', () => ({
   taskEventBus: {
     subscribe: vi.fn().mockReturnValue(vi.fn()), // returns unsubscribe fn

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neumar"
-version = "26.8.27"
+version = "26.9.9"
 description = "A desktop AI agent application that works tirelessly like a bull and horse to execute tasks through natural language."
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Neumar",
-  "version": "26.8.27",
+  "version": "26.9.9",
   "identifier": "ai.neumar",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -87,7 +87,9 @@ export default defineConfig(async () => ({
         ],
       },
       workbox: {
-        maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
+        // The React/Radix vendor chunk is currently about 4.42 MiB. Keep it
+        // precached while retaining a finite guard against accidental large assets.
+        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
         runtimeCaching: [
           {


### PR DESCRIPTION
## Summary
- Bump version to 26.9.9 across package.json, src-api/package.json, tauri.conf.json, and Cargo.toml
- Add the v26.9.9 release entry to CHANGELOG.md

## Test plan
- pnpm release:local:r2:mac-arm
  - Signed and Apple-notarized the ARM64 app and DMG
  - Verified codesign, stapling, and DMG checksum
  - Uploaded artifacts and latest.json to Cloudflare R2; purged stable CDN URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release information covering Video Mode planning, external-footage export, inbound MCP connections from Codex and Claude Code, and audio-asset validation for video workflows.

- **Chores**
  - Updated the application and supporting components to version 26.9.9.
  - Improved test isolation for agent API coverage involving external MCP connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->