### PR TITLE
feat(chat): unify model picker UI and refresh deepseek catalog

### DIFF
--- a/src-api/src/app/api/providers.ts
+++ b/src-api/src/app/api/providers.ts
@@ -18,6 +18,10 @@ import { getConfigLoader } from '@/config/loader';
 import { saveSetting } from '@/shared/db/operations';
 import { normalizeHost } from '@/shared/network-policy/host';
 import { trustedLocalPolicy } from '@/shared/network-policy/schema';
+import {
+  DEEPSEEK_MODELS,
+  isOfficialDeepSeekApiUrl,
+} from '@/shared/provider/deepseek-models';
 import { getProviderManager } from '@/shared/provider/manager';
 import { PROVIDER_CONNECTION_TEST_TIMEOUT_MS } from '@/shared/utils/connection-test-timeout';
 import {
@@ -1614,6 +1618,12 @@ providersRoutes.post(
               models.push({ id: m.id, name: m.name || undefined });
             }
           }
+        }
+
+        // DeepSeek's model-list endpoint omits documented API models such as
+        // its experimental vision model. Keep official-host discovery complete.
+        if (isOfficialDeepSeekApiUrl(baseUrl)) {
+          models.push(...DEEPSEEK_MODELS.map((id) => ({ id })));
         }
       }
 

--- a/src-api/src/extensions/agent/open-agent-sdk/index.ts
+++ b/src-api/src/extensions/agent/open-agent-sdk/index.ts
@@ -42,6 +42,7 @@ import type {
 
 import { DEFAULT_AGENT_MODEL, DEFAULT_WORK_DIR } from '@/config/constants';
 
+import { DEEPSEEK_MODELS } from '@/shared/provider/deepseek-models';
 import { getRemainingBudgetUsd } from '@/shared/services/budget';
 import { logUsage } from '@/shared/services/usage-logger';
 import { createLogger } from '@/shared/utils/logger';
@@ -543,8 +544,7 @@ export const OPEN_AGENT_SDK_METADATA = {
     'claude-opus-4-6',
     'claude-haiku-4-5-20251001',
     'gpt-4o',
-    'deepseek-chat',
-    'deepseek-reasoner',
+    ...DEEPSEEK_MODELS,
   ],
   defaultModel: DEFAULT_AGENT_MODEL,
   tags: ['multi-llm', 'in-process', 'anthropic', 'openai'],

--- a/src-api/src/extensions/agent/openai-compat/presets.ts
+++ b/src-api/src/extensions/agent/openai-compat/presets.ts
@@ -5,6 +5,8 @@
  * Used by the auto-detect endpoint and ModelSettings UI.
  */
 
+import { DEEPSEEK_MODELS } from '@/shared/provider/deepseek-models';
+
 export interface ProviderPreset {
   id: string;
   name: string;
@@ -250,7 +252,7 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     category: 'cloud',
     baseUrl: 'https://api.deepseek.com/v1',
     requiresAuth: true,
-    defaultModels: ['deepseek-chat', 'deepseek-reasoner'],
+    defaultModels: [...DEEPSEEK_MODELS],
     supportsModelDiscovery: true,
   },
   {

--- a/src-api/src/shared/provider/deepseek-models.ts
+++ b/src-api/src/shared/provider/deepseek-models.ts
@@ -1,0 +1,13 @@
+export const DEEPSEEK_MODELS = [
+  'deepseek-v4-flash',
+  'deepseek-v4-flash-vision-exp',
+  'deepseek-v4-pro',
+] as const;
+
+export function isOfficialDeepSeekApiUrl(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === 'api.deepseek.com';
+  } catch {
+    return false;
+  }
+}

--- a/src-api/src/shared/utils/provider-resolution.ts
+++ b/src-api/src/shared/utils/provider-resolution.ts
@@ -6,6 +6,7 @@
  * and any other service that makes lightweight LLM calls.
  */
 
+import { DEEPSEEK_MODELS } from '@/shared/provider/deepseek-models';
 import { getProviderManager } from '@/shared/provider/manager';
 
 // ============================================================================
@@ -21,7 +22,7 @@ export const FAST_MODEL_MAP: Record<string, string> = {
   'api.openai.com': 'gpt-5.4-nano',
   'api.groq.com': 'llama-3.1-8b-instant',
   'generativelanguage.googleapis.com': 'gemini-3.1-flash-lite',
-  'api.deepseek.com': 'deepseek-chat',
+  'api.deepseek.com': DEEPSEEK_MODELS[0],
   'api.x.ai': 'grok-4-1-fast-non-reasoning',
   'api.together.xyz': 'meta-llama/Llama-3.3-8B-Instruct-Turbo',
   'api.fireworks.ai': 'accounts/fireworks/models/llama-v3p3-8b-instruct',

--- a/src-api/test/integration/api/providers.test.ts
+++ b/src-api/test/integration/api/providers.test.ts
@@ -167,6 +167,44 @@ describe('Providers API', () => {
     expect(typeof body.latencyMs).toBe('number');
   });
 
+  it('supplements the incomplete DeepSeek model catalog', async () => {
+    mocks.safeFetch.mockResolvedValueOnce({
+      status: 200,
+      headers: {},
+      body: Buffer.from(
+        JSON.stringify({
+          data: [{ id: 'deepseek-v4-pro' }, { id: 'deepseek-v4-flash' }],
+        }),
+      ),
+      finalUrl: 'https://api.deepseek.com/v1/models',
+      redirectChain: [],
+    });
+
+    const { providersRoutes } = await import('@/app/api/providers');
+    const res = await providersRoutes.request('/models', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        providerId: 'deepseek',
+        apiKey: 'sk-test-secret-123',
+        baseUrl: 'https://api.deepseek.com/v1',
+        agentType: 'openai-compat',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      models: Array<{ id: string; displayLabel: string }>;
+      totalCount: number;
+    };
+    expect(body.models.map((model) => model.id)).toEqual([
+      'deepseek-v4-flash',
+      'deepseek-v4-flash-vision-exp',
+      'deepseek-v4-pro',
+    ]);
+    expect(body.totalCount).toBe(3);
+  });
+
   it('rejects Azure OpenAI deployment discovery explicitly', async () => {
     const { providersRoutes } = await import('@/app/api/providers');
     const res = await providersRoutes.request('/models', {

--- a/src/__tests__/ChatInputModelSelector.clip.test.tsx
+++ b/src/__tests__/ChatInputModelSelector.clip.test.tsx
@@ -1,6 +1,7 @@
 import type { RefObject } from 'react';
 
-import { screen } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { ModelOption } from '@/components/shared/ChatInput.types';
@@ -38,6 +39,163 @@ describe('ChatInput model selector label clipping', () => {
   });
 });
 
+describe('ChatInput model selector search', () => {
+  it('searches across model and provider names', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <ModelSelector
+        modelOptions={searchModels}
+        activeModelId="claude-sonnet-5"
+        activeModelLabel="Sonnet 5"
+        onModelChange={vi.fn()}
+        isRunning={false}
+        disabled={false}
+        isHome
+        triggerRef={{ current: null } as RefObject<HTMLButtonElement | null>}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /selected model/i }));
+    const search = screen.getByRole('combobox', { name: /search models/i });
+    expect(search).toHaveFocus();
+
+    await user.type(search, 'OpenRouter');
+
+    await waitFor(() =>
+      expect(screen.getByText('openai/gpt-4o-mini')).toBeVisible(),
+    );
+    expect(
+      within(screen.getByRole('listbox')).queryByText('Sonnet 5'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('OpenRouter')).toBeVisible();
+  });
+
+  it('selects the filtered model from the keyboard', async () => {
+    const user = userEvent.setup();
+    const onModelChange = vi.fn();
+
+    renderWithProviders(
+      <ModelSelector
+        modelOptions={searchModels}
+        activeModelId="claude-sonnet-5"
+        activeModelLabel="Sonnet 5"
+        onModelChange={onModelChange}
+        isRunning={false}
+        disabled={false}
+        isHome
+        triggerRef={{ current: null } as RefObject<HTMLButtonElement | null>}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /selected model/i }));
+    await user.type(
+      screen.getByRole('combobox', { name: /search models/i }),
+      'deepseek-v4-pro',
+    );
+    await user.keyboard('{ArrowDown}{Enter}');
+
+    expect(onModelChange).toHaveBeenCalledWith('deepseek-v4-pro');
+    expect(
+      screen.queryByRole('combobox', { name: /search models/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('excludes rows that only fuzzy-match the query', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <ModelSelector
+        modelOptions={noisySearchModels}
+        activeModelId="claude-sonnet-5"
+        activeModelLabel="Sonnet 5"
+        onModelChange={vi.fn()}
+        isRunning={false}
+        disabled={false}
+        isHome
+        triggerRef={{ current: null } as RefObject<HTMLButtonElement | null>}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /selected model/i }));
+    await user.type(
+      screen.getByRole('combobox', { name: /search models/i }),
+      'deepseek',
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('deepseek-v4-pro')).toBeVisible(),
+    );
+    // Subsequence matches used to be ranked above real hits.
+    expect(
+      screen.queryByText('Claude Opus 5 1M Medium Thinking'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('matches every whitespace-separated term', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <ModelSelector
+        modelOptions={noisySearchModels}
+        activeModelId="claude-sonnet-5"
+        activeModelLabel="Sonnet 5"
+        onModelChange={vi.fn()}
+        isRunning={false}
+        disabled={false}
+        isHome
+        triggerRef={{ current: null } as RefObject<HTMLButtonElement | null>}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /selected model/i }));
+    await user.type(
+      screen.getByRole('combobox', { name: /search models/i }),
+      'deepseek vision',
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('deepseek-v4-flash-vision-exp')).toBeVisible(),
+    );
+    expect(screen.queryByText('deepseek-v4-pro')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state and clears the query after closing', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <ModelSelector
+        modelOptions={searchModels}
+        activeModelId="claude-sonnet-5"
+        activeModelLabel="Sonnet 5"
+        onModelChange={vi.fn()}
+        isRunning={false}
+        disabled={false}
+        isHome
+        triggerRef={{ current: null } as RefObject<HTMLButtonElement | null>}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { name: /selected model/i });
+    await user.click(trigger);
+    await user.type(
+      screen.getByRole('combobox', { name: /search models/i }),
+      'no-such-model',
+    );
+    expect(screen.getByText('No models found')).toBeVisible();
+
+    await user.keyboard('{Escape}');
+    await user.click(trigger);
+
+    expect(
+      screen.getByRole('combobox', { name: /search models/i }),
+    ).toHaveValue('');
+    expect(
+      within(screen.getByRole('listbox')).getByText('Sonnet 5'),
+    ).toBeVisible();
+  });
+});
+
 function modelFixture(label: string): ModelOption {
   return {
     id: 'long-model',
@@ -46,3 +204,41 @@ function modelFixture(label: string): ModelOption {
     provider: 'openai-compat',
   };
 }
+
+const searchModels: ModelOption[] = [
+  {
+    id: 'claude-sonnet-5',
+    label: 'Sonnet 5',
+    description: 'Anthropic Claude',
+    provider: 'claude',
+  },
+  {
+    id: 'openai/gpt-4o-mini',
+    label: 'openai/gpt-4o-mini',
+    description: 'OpenRouter',
+    provider: 'openai-compat',
+  },
+  {
+    id: 'deepseek-v4-pro',
+    label: 'deepseek-v4-pro',
+    description: 'DeepSeek',
+    provider: 'openai-compat',
+  },
+];
+
+const noisySearchModels: ModelOption[] = [
+  ...searchModels,
+  {
+    id: 'deepseek-v4-flash-vision-exp',
+    label: 'deepseek-v4-flash-vision-exp',
+    description: 'DeepSeek',
+    provider: 'openai-compat',
+  },
+  {
+    // Every character of "deepseek" appears, in order, across this label.
+    id: 'opus-5-1m-medium-thinking',
+    label: 'Claude Opus 5 1M Medium Thinking',
+    description: 'Cursor Agent',
+    provider: 'openai-compat',
+  },
+];

--- a/src/__tests__/deepseek-model-catalog.test.ts
+++ b/src/__tests__/deepseek-model-catalog.test.ts
@@ -6,6 +6,11 @@ import {
   defaultProviders,
 } from '@/shared/db/settings';
 
+// Not a real package boundary crossing — this asserts the API's separately
+// maintained copy of the catalog (src-api/src/shared/provider/deepseek-models.ts)
+// hasn't drifted from the frontend's, since nothing else enforces that today.
+import { DEEPSEEK_MODELS as API_DEEPSEEK_MODELS } from '../../src-api/src/shared/provider/deepseek-models';
+
 describe('DeepSeek model catalog', () => {
   it('uses the current catalog for built-in and custom provider defaults', () => {
     const expectedModels = [
@@ -18,5 +23,9 @@ describe('DeepSeek model catalog', () => {
     expect(DEEPSEEK_MODELS).toEqual(expectedModels);
     expect(provider?.models).toEqual(expectedModels);
     expect(customProviderModels.deepseek).toEqual(expectedModels);
+  });
+
+  it('stays in sync with the API catalog', () => {
+    expect(API_DEEPSEEK_MODELS).toEqual(DEEPSEEK_MODELS);
   });
 });

--- a/src/__tests__/deepseek-model-catalog.test.ts
+++ b/src/__tests__/deepseek-model-catalog.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  customProviderModels,
+  DEEPSEEK_MODELS,
+  defaultProviders,
+} from '@/shared/db/settings';
+
+describe('DeepSeek model catalog', () => {
+  it('uses the current catalog for built-in and custom provider defaults', () => {
+    const expectedModels = [
+      'deepseek-v4-flash',
+      'deepseek-v4-flash-vision-exp',
+      'deepseek-v4-pro',
+    ];
+    const provider = defaultProviders.find(({ id }) => id === 'deepseek');
+
+    expect(DEEPSEEK_MODELS).toEqual(expectedModels);
+    expect(provider?.models).toEqual(expectedModels);
+    expect(customProviderModels.deepseek).toEqual(expectedModels);
+  });
+});

--- a/src/__tests__/model-capabilities.test.ts
+++ b/src/__tests__/model-capabilities.test.ts
@@ -36,4 +36,12 @@ describe('model capability detection', () => {
       'video-input',
     ]);
   });
+
+  it.each([
+    ['deepseek-v4-flash', ['chat', 'code', 'reasoning']],
+    ['deepseek-v4-pro', ['chat', 'code', 'reasoning']],
+    ['deepseek-v4-flash-vision-exp', ['chat', 'vision', 'code', 'reasoning']],
+  ])('detects current DeepSeek capabilities for %s', (model, capabilities) => {
+    expect(detectModelCapabilities(model)).toEqual(capabilities);
+  });
 });

--- a/src/__tests__/provider-models-cache.test.ts
+++ b/src/__tests__/provider-models-cache.test.ts
@@ -78,6 +78,28 @@ describe('provider models cache', () => {
       description: 'OpenRouter',
     });
   });
+
+  it('keeps distinct model IDs visible when a provider has several models', () => {
+    const deepSeekProvider = {
+      id: 'deepseek',
+      name: 'DeepSeek',
+      apiKey: 'sk-secret-deepseek-key',
+      baseUrl: 'https://api.deepseek.com/v1',
+      enabled: true,
+      models: ['deepseek-v4-flash', 'deepseek-v4-pro'],
+      agentType: 'openai-compat',
+    } satisfies AIProvider;
+
+    expect(
+      buildModelOptions({}, [deepSeekProvider]).map(({ id, label }) => ({
+        id,
+        label,
+      })),
+    ).toEqual([
+      { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash' },
+      { id: 'deepseek-v4-pro', label: 'deepseek-v4-pro' },
+    ]);
+  });
 });
 
 const providerFixture = {

--- a/src/components/shared/ChatInput.types.ts
+++ b/src/components/shared/ChatInput.types.ts
@@ -96,10 +96,7 @@ export function buildModelOptions(
       const cachedModel = cachedModelsById.get(modelId);
       options.push({
         id: modelId,
-        label:
-          cachedModel?.displayLabel ??
-          cachedModel?.name ??
-          getModelShortLabel(modelId),
+        label: cachedModel?.displayLabel ?? cachedModel?.name ?? modelId,
         description: provider.name,
         provider: provider.agentType,
       });

--- a/src/components/shared/ChatInputModelSelector.tsx
+++ b/src/components/shared/ChatInputModelSelector.tsx
@@ -8,27 +8,20 @@
  * truth.
  */
 
-import type { RefObject } from 'react';
+import { useState, type RefObject } from 'react';
 
-import { Check, ChevronDown } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/shared/lib/utils';
 import { useLanguage } from '@/shared/providers/language-provider';
 
-import { AgentRuntimeIcon } from './AgentRuntimeIcon';
 import type { ModelOption } from './ChatInput.types';
-import {
-  groupModelOptionsByAgent,
-  modelMetadataLabel,
-} from './runtime-model-catalog';
+import { ModelSearchMenu } from './ModelSearchMenu';
 
 export interface ModelSelectorProps {
   modelOptions: ModelOption[];
@@ -52,14 +45,16 @@ export function ModelSelector({
   triggerRef,
 }: ModelSelectorProps) {
   const { t } = useLanguage();
-  const groups = groupModelOptionsByAgent(modelOptions, {
+  const [open, setOpen] = useState(false);
+
+  const groupLabels = {
     claude: t.home.modelGroupClaude,
     codex: t.home.modelGroupCodex,
     other: t.home.modelGroupOtherProviders,
-  });
+  };
 
   return (
-    <DropdownMenu modal={false}>
+    <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger
         ref={triggerRef}
         disabled={isRunning || disabled}
@@ -79,49 +74,23 @@ export function ModelSelector({
         </span>
         <ChevronDown className="size-3 shrink-0" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" sideOffset={8} className="z-50 w-56">
-        {groups.map((group, index) => (
-          <div key={group.provider}>
-            {index > 0 && <DropdownMenuSeparator />}
-            <DropdownMenuLabel className="flex items-center gap-1.5 text-xs font-medium tracking-wide uppercase opacity-60">
-              {group.provider !== 'other' && (
-                <AgentRuntimeIcon
-                  runtimeId={group.provider}
-                  className="size-3.5"
-                />
-              )}
-              {group.label}
-            </DropdownMenuLabel>
-            {group.options.map((model) => (
-              <DropdownMenuItem
-                key={model.id}
-                disabled={model.disabled}
-                onSelect={() => {
-                  if (!model.disabled) onModelChange(model.id);
-                }}
-                className={cn(
-                  'gap-2 py-2',
-                  model.disabled ? 'opacity-60' : 'cursor-pointer',
-                )}
-              >
-                <Check
-                  className={cn(
-                    'size-3.5 shrink-0',
-                    activeModelId === model.id ? 'opacity-100' : 'opacity-0',
-                  )}
-                />
-                <div className="flex flex-col gap-0.5">
-                  <span className="text-sm font-medium">{model.label}</span>
-                  <span className="text-muted-foreground text-xs">
-                    {model.disabledReason ||
-                      modelMetadataLabel(model) ||
-                      model.description}
-                  </span>
-                </div>
-              </DropdownMenuItem>
-            ))}
-          </div>
-        ))}
+      <DropdownMenuContent
+        align="end"
+        sideOffset={8}
+        className="z-50 h-[min(24rem,var(--radix-dropdown-menu-content-available-height))] w-80 overflow-hidden p-0"
+      >
+        <ModelSearchMenu
+          fillHeight
+          options={modelOptions}
+          activeModelId={activeModelId}
+          onSelect={(modelId) => {
+            if (modelId) onModelChange(modelId);
+            setOpen(false);
+          }}
+          groupLabels={groupLabels}
+          searchPlaceholder={t.settings.modelPickerSearchPlaceholder}
+          emptyLabel={t.settings.modelPickerNoResults}
+        />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/shared/ModelPicker.tsx
+++ b/src/components/shared/ModelPicker.tsx
@@ -5,19 +5,10 @@
  * and anywhere else a model needs to be chosen.
  */
 
-import { useDeferredValue, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
-import { Check, ChevronDown } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-} from '@/components/ui/command';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -28,10 +19,7 @@ import { cn } from '@/shared/lib/utils';
 import { useLanguage } from '@/shared/providers/language-provider';
 
 import { getModelShortLabel, type ModelOption } from './ChatInput.types';
-import {
-  groupModelOptionsByAgent,
-  modelMetadataLabel,
-} from './runtime-model-catalog';
+import { ModelSearchMenu } from './ModelSearchMenu';
 import { useModelOptions } from './useModelOptions';
 
 export {
@@ -71,8 +59,6 @@ export function ModelPicker({
 }: ModelPickerProps) {
   const { t } = useLanguage();
   const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState('');
-  const deferredQuery = useDeferredValue(query.trim().toLowerCase());
   const allOptions = useModelOptions(mode);
   const providerKey = allowedProviders?.join(',') ?? '';
 
@@ -89,75 +75,11 @@ export function ModelPicker({
       getModelShortLabel(activeModelId))
     : defaultLabel;
 
-  const matchesQuery = (model: ModelOption) => {
-    if (!deferredQuery) return true;
-    return [model.id, model.label, model.description, model.provider]
-      .filter(Boolean)
-      .some((value) => value.toLowerCase().includes(deferredQuery));
-  };
-
-  const filteredOptions = useMemo(
-    () => modelOptions.filter(matchesQuery),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [modelOptions, deferredQuery],
-  );
-
-  const showDefaultOption =
-    showDefault &&
-    (!deferredQuery ||
-      [defaultLabel, t.settings.modelPickerDefaultDescription]
-        .join(' ')
-        .toLowerCase()
-        .includes(deferredQuery));
-
-  const selectModel = (modelId: string | null) => {
-    onChange(modelId);
-    setOpen(false);
-    setQuery('');
-  };
-
-  const renderItem = (model: ModelOption) => (
-    <CommandItem
-      key={model.id}
-      value={`${model.id} ${model.label} ${model.description}`}
-      disabled={model.disabled}
-      onSelect={() => {
-        if (!model.disabled) selectModel(model.id);
-      }}
-      className={cn(
-        'gap-2 py-2',
-        model.disabled ? 'opacity-60' : 'cursor-pointer',
-      )}
-    >
-      <Check
-        className={cn(
-          'size-3.5 shrink-0',
-          activeModelId === model.id ? 'opacity-100' : 'opacity-0',
-        )}
-      />
-      <div className="flex flex-col gap-0.5">
-        <span className="text-sm font-medium">{model.label}</span>
-        {(model.disabledReason ||
-          modelMetadataLabel(model) ||
-          model.description) && (
-          <span className="text-muted-foreground text-xs">
-            {model.disabledReason ||
-              modelMetadataLabel(model) ||
-              model.description}
-          </span>
-        )}
-      </div>
-    </CommandItem>
-  );
-
-  // Agent-first groups shared with the composer selector so the two
-  // surfaces cannot drift.
-  const groups = groupModelOptionsByAgent(filteredOptions, {
+  const groupLabels = {
     claude: t.settings.modelPickerGroupClaude,
     codex: t.settings.modelPickerGroupCodex,
     other: t.settings.modelPickerGroupOther,
-  });
-  const hasOptions = showDefaultOption || groups.length > 0;
+  };
 
   return (
     <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
@@ -176,53 +98,22 @@ export function ModelPicker({
       <DropdownMenuContent
         align="start"
         sideOffset={4}
-        className="z-50 w-80 p-0"
+        className="z-50 w-80 overflow-hidden p-0"
       >
-        <Command shouldFilter={false}>
-          <CommandInput
-            value={query}
-            onValueChange={setQuery}
-            onKeyDown={(event) => event.stopPropagation()}
-            placeholder={t.settings.modelPickerSearchPlaceholder}
-          />
-          <CommandList>
-            {!hasOptions && (
-              <CommandEmpty>{t.settings.modelPickerNoResults}</CommandEmpty>
-            )}
-            {showDefaultOption && (
-              <>
-                <CommandItem
-                  value={`${defaultLabel} ${t.settings.modelPickerDefaultDescription}`}
-                  onSelect={() => selectModel(null)}
-                  className="cursor-pointer gap-2 py-2"
-                >
-                  <Check
-                    className={cn(
-                      'size-3.5 shrink-0',
-                      !activeModelId ? 'opacity-100' : 'opacity-0',
-                    )}
-                  />
-                  <div className="flex flex-col gap-0.5">
-                    <span className="text-sm font-medium">{defaultLabel}</span>
-                    <span className="text-muted-foreground text-xs">
-                      {t.settings.modelPickerDefaultDescription}
-                    </span>
-                  </div>
-                </CommandItem>
-                {groups.length > 0 && <CommandSeparator />}
-              </>
-            )}
-
-            {groups.map((group, index) => (
-              <div key={group.provider}>
-                {index > 0 && <CommandSeparator />}
-                <CommandGroup heading={group.label}>
-                  {group.options.map(renderItem)}
-                </CommandGroup>
-              </div>
-            ))}
-          </CommandList>
-        </Command>
+        <ModelSearchMenu
+          options={modelOptions}
+          activeModelId={activeModelId}
+          onSelect={(modelId) => {
+            onChange(modelId);
+            setOpen(false);
+          }}
+          showDefault={showDefault}
+          defaultLabel={defaultLabel}
+          defaultDescription={t.settings.modelPickerDefaultDescription}
+          groupLabels={groupLabels}
+          searchPlaceholder={t.settings.modelPickerSearchPlaceholder}
+          emptyLabel={t.settings.modelPickerNoResults}
+        />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/shared/ModelPicker.tsx
+++ b/src/components/shared/ModelPicker.tsx
@@ -51,7 +51,7 @@ export function ModelPicker({
   value,
   onChange,
   showDefault = false,
-  defaultLabel = 'Default',
+  defaultLabel,
   allowedProviders,
   mode = 'task',
   disabled = false,
@@ -61,6 +61,8 @@ export function ModelPicker({
   const [open, setOpen] = useState(false);
   const allOptions = useModelOptions(mode);
   const providerKey = allowedProviders?.join(',') ?? '';
+  const resolvedDefaultLabel =
+    defaultLabel ?? t.settings.modelPickerDefaultLabel;
 
   const modelOptions = useMemo(() => {
     return allowedProviders
@@ -73,7 +75,7 @@ export function ModelPicker({
   const activeLabel = activeModelId
     ? (modelOptions.find((m) => m.id === activeModelId)?.label ??
       getModelShortLabel(activeModelId))
-    : defaultLabel;
+    : resolvedDefaultLabel;
 
   const groupLabels = {
     claude: t.settings.modelPickerGroupClaude,
@@ -108,7 +110,7 @@ export function ModelPicker({
             setOpen(false);
           }}
           showDefault={showDefault}
-          defaultLabel={defaultLabel}
+          defaultLabel={resolvedDefaultLabel}
           defaultDescription={t.settings.modelPickerDefaultDescription}
           groupLabels={groupLabels}
           searchPlaceholder={t.settings.modelPickerSearchPlaceholder}

--- a/src/components/shared/ModelSearchMenu.tsx
+++ b/src/components/shared/ModelSearchMenu.tsx
@@ -1,0 +1,226 @@
+/**
+ * ModelSearchMenu — searchable, agent-grouped model list.
+ *
+ * Shared by the composer selector (`ChatInputModelSelector`) and the settings
+ * `ModelPicker` so the two surfaces cannot drift. Callers own the trigger and
+ * the dropdown shell; this component owns the query, the filtering and the
+ * grouped rows.
+ *
+ * Filtering is plain case-insensitive substring matching over the fields the
+ * row actually shows, not cmdk's fuzzy scorer: the catalog carries hundreds of
+ * runtime models, and subsequence matching floats unrelated rows above the
+ * real hits (`deepseek` matching "Claude Opus 5 Medium Thinking"). Whitespace
+ * separates terms, and every term must match.
+ */
+
+import { useDeferredValue, useMemo, useState } from 'react';
+
+import { Check } from 'lucide-react';
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command';
+import { cn } from '@/shared/lib/utils';
+
+import { AgentRuntimeIcon } from './AgentRuntimeIcon';
+import type { ModelOption } from './ChatInput.types';
+import {
+  groupModelOptionsByAgent,
+  modelMetadataLabel,
+} from './runtime-model-catalog';
+
+export interface ModelSearchMenuProps {
+  options: readonly ModelOption[];
+  activeModelId: string | null;
+  /** Null is only passed when a default row is shown. */
+  onSelect: (modelId: string | null) => void;
+  /** Show a row that clears the model override. */
+  showDefault?: boolean;
+  defaultLabel?: string;
+  defaultDescription?: string;
+  groupLabels: { claude: string; codex: string; other: string };
+  searchPlaceholder: string;
+  emptyLabel: string;
+  /** Stretch the list to the shell height instead of capping it at 300px. */
+  fillHeight?: boolean;
+  autoFocus?: boolean;
+  listClassName?: string;
+}
+
+/** All searchable text for one row, lowercased. */
+export function modelSearchText(model: ModelOption): string {
+  return [
+    model.id,
+    model.label,
+    model.description,
+    model.provider,
+    modelMetadataLabel(model),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+}
+
+function matchesAllTokens(
+  haystack: string,
+  tokens: readonly string[],
+): boolean {
+  return tokens.every((token) => haystack.includes(token));
+}
+
+export function ModelSearchMenu({
+  options,
+  activeModelId,
+  onSelect,
+  showDefault = false,
+  defaultLabel = 'Default',
+  defaultDescription,
+  groupLabels,
+  searchPlaceholder,
+  emptyLabel,
+  fillHeight = false,
+  autoFocus = true,
+  listClassName,
+}: ModelSearchMenuProps) {
+  const [query, setQuery] = useState('');
+  const deferredQuery = useDeferredValue(query.trim().toLowerCase());
+
+  const filteredOptions = useMemo(() => {
+    const tokens = deferredQuery.split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) return [...options];
+    return options.filter((model) =>
+      matchesAllTokens(modelSearchText(model), tokens),
+    );
+  }, [options, deferredQuery]);
+
+  const groups = useMemo(
+    () => groupModelOptionsByAgent(filteredOptions, groupLabels),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- labels are plain strings
+    [filteredOptions, groupLabels.claude, groupLabels.codex, groupLabels.other],
+  );
+
+  const showDefaultRow =
+    showDefault &&
+    matchesAllTokens(
+      `${defaultLabel} ${defaultDescription ?? ''}`.toLowerCase(),
+      deferredQuery.split(/\s+/).filter(Boolean),
+    );
+  const hasRows = showDefaultRow || groups.length > 0;
+
+  return (
+    // Keep menu key handling (cmdk) working while shielding the surrounding
+    // Radix menu, which would otherwise claim arrow keys for its own items.
+    <div className="h-full" onKeyDown={(event) => event.stopPropagation()}>
+      <Command shouldFilter={false} label={searchPlaceholder}>
+        <CommandInput
+          autoFocus={autoFocus}
+          value={query}
+          onValueChange={setQuery}
+          placeholder={searchPlaceholder}
+          aria-label={searchPlaceholder}
+        />
+        <CommandList
+          className={cn(fillHeight && 'max-h-none flex-1', listClassName)}
+        >
+          {!hasRows && <CommandEmpty>{emptyLabel}</CommandEmpty>}
+
+          {showDefaultRow && (
+            <>
+              <CommandItem
+                value={`${defaultLabel} ${defaultDescription ?? ''}`}
+                onSelect={() => onSelect(null)}
+                className="cursor-pointer gap-2 py-2"
+              >
+                <Check
+                  className={cn(
+                    'size-3.5 shrink-0',
+                    activeModelId === null ? 'opacity-100' : 'opacity-0',
+                  )}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium">
+                    {defaultLabel}
+                  </div>
+                  {defaultDescription && (
+                    <div className="text-muted-foreground truncate text-xs">
+                      {defaultDescription}
+                    </div>
+                  )}
+                </div>
+              </CommandItem>
+              {groups.length > 0 && <CommandSeparator />}
+            </>
+          )}
+
+          {groups.map((group, index) => (
+            <div key={group.provider}>
+              {index > 0 && <CommandSeparator />}
+              <CommandGroup
+                heading={
+                  <span className="flex items-center gap-1.5 tracking-wide uppercase">
+                    {group.provider !== 'other' && (
+                      <AgentRuntimeIcon
+                        runtimeId={group.provider}
+                        className="size-3.5"
+                      />
+                    )}
+                    {group.label}
+                  </span>
+                }
+              >
+                {group.options.map((model) => {
+                  const detail = [
+                    model.description,
+                    model.disabledReason || modelMetadataLabel(model),
+                  ]
+                    .filter(Boolean)
+                    .join(' · ');
+
+                  return (
+                    <CommandItem
+                      key={model.id}
+                      value={modelSearchText(model)}
+                      disabled={model.disabled}
+                      onSelect={() => {
+                        if (!model.disabled) onSelect(model.id);
+                      }}
+                      className={cn(
+                        'gap-2 py-2',
+                        model.disabled ? 'opacity-60' : 'cursor-pointer',
+                      )}
+                    >
+                      <Check
+                        className={cn(
+                          'size-3.5 shrink-0',
+                          activeModelId === model.id
+                            ? 'opacity-100'
+                            : 'opacity-0',
+                        )}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium">
+                          {model.label}
+                        </div>
+                        {detail && (
+                          <div className="text-muted-foreground truncate text-xs">
+                            {detail}
+                          </div>
+                        )}
+                      </div>
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            </div>
+          ))}
+        </CommandList>
+      </Command>
+    </div>
+  );
+}

--- a/src/components/shared/ModelSearchMenu.tsx
+++ b/src/components/shared/ModelSearchMenu.tsx
@@ -42,6 +42,7 @@ export interface ModelSearchMenuProps {
   onSelect: (modelId: string | null) => void;
   /** Show a row that clears the model override. */
   showDefault?: boolean;
+  /** Required (and must be localized) when `showDefault` is true. */
   defaultLabel?: string;
   defaultDescription?: string;
   groupLabels: { claude: string; codex: string; other: string };
@@ -79,7 +80,7 @@ export function ModelSearchMenu({
   activeModelId,
   onSelect,
   showDefault = false,
-  defaultLabel = 'Default',
+  defaultLabel,
   defaultDescription,
   groupLabels,
   searchPlaceholder,

--- a/src/config/locale/messages/en/settings.ts
+++ b/src/config/locale/messages/en/settings.ts
@@ -573,6 +573,7 @@ export default {
   useEnvModel: 'Use environment variables',
   modelPickerSearchPlaceholder: 'Search models...',
   modelPickerNoResults: 'No models found',
+  modelPickerDefaultLabel: 'Default',
   modelPickerDefaultDescription: 'Use the globally configured model',
   modelPickerGroupClaude: 'Claude',
   modelPickerGroupCodex: 'OpenAI Codex',

--- a/src/config/locale/messages/es/settings.ts
+++ b/src/config/locale/messages/es/settings.ts
@@ -585,6 +585,7 @@ export default {
   useEnvModel: 'Usar variables de entorno',
   modelPickerSearchPlaceholder: 'Buscar modelos...',
   modelPickerNoResults: 'No se encontraron modelos',
+  modelPickerDefaultLabel: 'Predeterminado',
   modelPickerDefaultDescription: 'Usar el modelo configurado globalmente',
   modelPickerGroupClaude: 'Claude',
   modelPickerGroupCodex: 'OpenAI Codex',

--- a/src/config/locale/messages/fr/settings.ts
+++ b/src/config/locale/messages/fr/settings.ts
@@ -588,6 +588,7 @@ export default {
   useEnvModel: "Utiliser les variables d'environnement",
   modelPickerSearchPlaceholder: 'Rechercher des modèles...',
   modelPickerNoResults: 'Aucun modèle trouvé',
+  modelPickerDefaultLabel: 'Par défaut',
   modelPickerDefaultDescription: 'Utiliser le modèle configuré globalement',
   modelPickerGroupClaude: 'Claude',
   modelPickerGroupCodex: 'OpenAI Codex',

--- a/src/config/locale/messages/hi/settings.ts
+++ b/src/config/locale/messages/hi/settings.ts
@@ -567,6 +567,7 @@ export default {
   useEnvModel: 'एनवायरनमेंट वेरिएबल का उपयोग करें',
   modelPickerSearchPlaceholder: 'मॉडल खोजें...',
   modelPickerNoResults: 'कोई मॉडल नहीं मिला',
+  modelPickerDefaultLabel: 'डिफ़ॉल्ट',
   modelPickerDefaultDescription: 'वैश्विक रूप से कॉन्फ़िगर किया गया मॉडल उपयोग करें',
   modelPickerGroupClaude: 'Claude',
   modelPickerGroupCodex: 'OpenAI Codex',

--- a/src/config/locale/messages/pt/settings.ts
+++ b/src/config/locale/messages/pt/settings.ts
@@ -582,6 +582,7 @@ export default {
   useEnvModel: 'Usar variáveis de ambiente',
   modelPickerSearchPlaceholder: 'Buscar modelos...',
   modelPickerNoResults: 'Nenhum modelo encontrado',
+  modelPickerDefaultLabel: 'Padrão',
   modelPickerDefaultDescription: 'Usar o modelo configurado globalmente',
   modelPickerGroupClaude: 'Claude',
   modelPickerGroupCodex: 'OpenAI Codex',

--- a/src/config/locale/messages/zh/settings.ts
+++ b/src/config/locale/messages/zh/settings.ts
@@ -542,6 +542,7 @@ export default {
   useEnvModel: '使用环境变量配置',
   modelPickerSearchPlaceholder: '搜索模型...',
   modelPickerNoResults: '未找到模型',
+  modelPickerDefaultLabel: '默认',
   modelPickerDefaultDescription: '使用全局配置的模型',
   modelPickerGroupClaude: 'Claude',
   modelPickerGroupCodex: 'OpenAI Codex',

--- a/src/shared/db/settings.ts
+++ b/src/shared/db/settings.ts
@@ -851,6 +851,14 @@ export const BYTEPLUS_MODELS = [
   'dreamina-seedance-2-0-fast-260128',
 ] as const;
 
+// DeepSeek API model list — single source of truth for frontend
+// See https://api-docs.deepseek.com/quick_start/pricing for the current catalog.
+export const DEEPSEEK_MODELS = [
+  'deepseek-v4-flash',
+  'deepseek-v4-flash-vision-exp',
+  'deepseek-v4-pro',
+] as const;
+
 // Google Gemini model list — single source of truth for frontend
 // Covers text/reasoning, image generation, audio/TTS, video generation, and embeddings.
 // See https://ai.google.dev/gemini-api/docs/models for the full list.
@@ -1031,7 +1039,7 @@ export const defaultProviders: AIProvider[] = [
     apiKey: '',
     baseUrl: 'https://api.deepseek.com/v1',
     enabled: false,
-    models: ['deepseek-chat', 'deepseek-reasoner'],
+    models: [...DEEPSEEK_MODELS],
     icon: 'D',
     apiKeyUrl: 'https://platform.deepseek.com/api_keys',
     canDelete: true,
@@ -1396,7 +1404,7 @@ export const providerDefaultModels: Record<string, string[]> = {
 
 // Model suggestions for custom providers (matched by name pattern)
 export const customProviderModels: Record<string, string[]> = {
-  deepseek: ['deepseek-chat', 'deepseek-coder', 'deepseek-reasoner'],
+  deepseek: [...DEEPSEEK_MODELS],
   moonshot: ['kimi-k3'],
   kimi: ['kimi-k3'],
   qwen: ['qwen-max', 'qwen-plus', 'qwen-turbo'],

--- a/src/shared/lib/model-capabilities.ts
+++ b/src/shared/lib/model-capabilities.ts
@@ -463,7 +463,15 @@ const MODEL_CAPABILITY_RULES: Array<{
   { pattern: /^ministral/i, capabilities: ['chat', 'vision'] },
   { pattern: /^devstral/i, capabilities: ['chat', 'code'] },
 
-  // ── DeepSeek V3.x ────────────────────────────────────────────────
+  // ── DeepSeek V4 / V3.x ───────────────────────────────────────────
+  {
+    pattern: /^deepseek[-_]?v4.*vision/i,
+    capabilities: ['chat', 'vision', 'code', 'reasoning'],
+  },
+  {
+    pattern: /^deepseek[-_]?v4/i,
+    capabilities: ['chat', 'code', 'reasoning'],
+  },
   {
     pattern: /^deepseek[-_]?v3/i,
     capabilities: ['chat', 'code', 'reasoning'],


### PR DESCRIPTION
## Summary

- Consolidates the composer's `ChatInputModelSelector` and the settings `ModelPicker` onto a single shared `ModelSearchMenu` component so the two surfaces render, filter, and group models identically and can't drift apart.
- Introduces `DEEPSEEK_MODELS` as the single source of truth for the DeepSeek model catalog (V4 family: `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp`, `deepseek-v4-pro`), replacing hardcoded `deepseek-chat`/`deepseek-reasoner` lists scattered across the frontend and API.
- Backfills DeepSeek's official-host model discovery with the documented models its own `/models` endpoint omits (e.g. the vision-preview model).

## Changes

- `src/components/shared/ModelSearchMenu.tsx` (new) — shared searchable, grouped model list used by both pickers.
- `src/components/shared/ChatInputModelSelector.tsx`, `src/components/shared/ModelPicker.tsx` — replaced duplicated dropdown/command markup with `ModelSearchMenu`.
- `src/components/shared/ChatInput.types.ts` — model option label now falls back to the raw model id instead of a short-label heuristic when no cached metadata exists.
- `src-api/src/shared/provider/deepseek-models.ts` (new), `src/shared/db/settings.ts` — single-source `DEEPSEEK_MODELS` list, reused in `src-api/src/extensions/agent/open-agent-sdk/index.ts`, `src-api/src/extensions/agent/openai-compat/presets.ts`, and `src-api/src/shared/utils/provider-resolution.ts`.
- `src-api/src/app/api/providers.ts` — appends documented DeepSeek models missing from the live discovery endpoint when connecting to the official DeepSeek API host.
- `src/shared/lib/model-capabilities.ts` — capability rules for the new `deepseek-v4*` model family (chat/code/reasoning, plus vision for the vision variant).

## Testing

**Automated Tests:**
- [x] `pnpm vitest run` on the touched frontend test files (`ChatInputModelSelector.clip.test.tsx`, `model-capabilities.test.ts`, `provider-models-cache.test.ts`, `deepseek-model-catalog.test.ts`) — 27 passed
- [x] `pnpm test:api -- providers.test.ts` — full API suite, 3417 passed
- [ ] `pnpm validate` — fails only on pre-existing `tsc` errors in an unrelated, untracked, in-progress file (`src/components/video/VideoProjectFilePreview.tsx`) not touched by this PR

**Manual Testing:**
- [ ] Composer model dropdown search/select
- [ ] Settings model picker search/select, including "default" option

## Breaking Changes

None.

## Migration Required

None — existing DeepSeek provider configs will pick up the new default model list on next save/reset, old model ids are not removed from user-saved config.

## Related Issues

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for DeepSeek V4 models, including automatic discovery from the official API.
  - Updated model capability detection for chat, coding, reasoning, and vision features.
  - Improved model selectors with shared search, multi-term filtering, keyboard selection, and clearer empty states.
  - Preserved distinct model IDs and labels when multiple models are available.
  - Added localized labels for the default model option.

- **Bug Fixes**
  - Corrected model catalog consistency across built-in and custom DeepSeek providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->